### PR TITLE
Add fund cash flows to seed, fix mobile footer, install BotID, right drawer for notes/analyst

### DIFF
--- a/app/(app)/companies/[id]/company-notes.tsx
+++ b/app/(app)/companies/[id]/company-notes.tsx
@@ -8,6 +8,7 @@ import { MentionTextarea, type MentionMember, type MentionTextareaRef } from '@/
 import { usePanelContext } from './company-panel-context'
 import { useAnalystContext } from '@/components/analyst-context'
 import { useFeatureVisibility } from '@/components/feature-visibility-context'
+import { MobileDrawerPanel } from '@/components/mobile-drawer-panel'
 
 interface Note {
   id: string
@@ -66,8 +67,11 @@ export function ChatButton() {
 
 export function CompanyNotesPanel() {
   const ctx = usePanelContext()
-  if (!ctx.notesOpen) return null
-  return <NotesPanel />
+  return (
+    <MobileDrawerPanel open={ctx.notesOpen} onOpenChange={(open) => { if (!open) ctx.closeNotes() }}>
+      <NotesPanel />
+    </MobileDrawerPanel>
+  )
 }
 
 function NotesPanel() {
@@ -183,8 +187,8 @@ function NotesPanel() {
   }
 
   return (
-    <div className="w-full lg:w-[340px] shrink-0 lg:sticky top-4">
-    <div className="max-h-[80vh] lg:max-h-[calc(100vh-6rem)] rounded-lg border bg-card flex flex-col">
+    <div className="flex flex-col h-full">
+    <div className="max-h-[80vh] lg:max-h-[calc(100vh-6rem)] rounded-lg border bg-card flex flex-col flex-1">
       <div className="px-4 py-3 flex items-center justify-between">
         <h2 className="text-sm font-medium text-muted-foreground">Notes</h2>
         <button onClick={closeNotes}>

--- a/app/(app)/dashboard/dashboard-notes.tsx
+++ b/app/(app)/dashboard/dashboard-notes.tsx
@@ -8,6 +8,7 @@ import { MentionTextarea, type MentionMember, type MentionTextareaRef } from '@/
 import { useAnalystContext } from '@/components/analyst-context'
 import { useFeatureVisibility } from '@/components/feature-visibility-context'
 import Link from 'next/link'
+import { MobileDrawerPanel } from '@/components/mobile-drawer-panel'
 
 interface Note {
   id: string
@@ -129,8 +130,12 @@ export function DashboardChatButton() {
 
 export function DashboardNotesPanel() {
   const ctx = useContext(DashboardNotesContext)
-  if (!ctx || !ctx.open) return null
-  return <NotesPanel ctx={ctx} />
+  if (!ctx) return null
+  return (
+    <MobileDrawerPanel open={ctx.open} onOpenChange={(open) => { if (!open) ctx.toggle() }}>
+      <NotesPanel ctx={ctx} />
+    </MobileDrawerPanel>
+  )
 }
 
 function NotesPanel({ ctx }: { ctx: NotesContextValue }) {
@@ -239,8 +244,8 @@ function NotesPanel({ ctx }: { ctx: NotesContextValue }) {
   }
 
   return (
-    <div className="w-full lg:w-[340px] shrink-0 lg:sticky top-4">
-    <div className="max-h-[80vh] lg:max-h-[calc(100vh-6rem)] rounded-lg border bg-card flex flex-col">
+    <div className="flex flex-col h-full">
+    <div className="max-h-[80vh] lg:max-h-[calc(100vh-6rem)] rounded-lg border bg-card flex flex-col flex-1">
       <div className="px-4 py-3 flex items-center justify-between">
         <h2 className="text-sm font-medium text-muted-foreground">Team Notes</h2>
         <button onClick={toggle}>

--- a/components/analyst-panel.tsx
+++ b/components/analyst-panel.tsx
@@ -6,6 +6,7 @@ import ReactMarkdown from 'react-markdown'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { useAnalystContext } from '@/components/analyst-context'
+import { MobileDrawerPanel } from '@/components/mobile-drawer-panel'
 
 export function AnalystPanel() {
   const {
@@ -47,8 +48,6 @@ export function AnalystPanel() {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight
     }
   }, [messages, loading])
-
-  if (!open) return null
 
   async function handleSend() {
     if (!input.trim() || loading) return
@@ -127,8 +126,9 @@ export function AnalystPanel() {
   const modelKey = selectedModel ? `${selectedModel.provider}:${selectedModel.id}` : 'auto'
 
   return (
-    <div className="w-full lg:w-[340px] shrink-0 lg:sticky top-4">
-    <div className="max-h-[80vh] lg:max-h-[calc(100vh-6rem)] rounded-lg border bg-card flex flex-col">
+    <MobileDrawerPanel open={open} onOpenChange={(isOpen) => { if (!isOpen) close() }}>
+    <div className="flex flex-col h-full">
+    <div className="max-h-[80vh] lg:max-h-[calc(100vh-6rem)] rounded-lg border bg-card flex flex-col flex-1">
         {/* Header */}
         <div className="px-4 py-3 flex items-center gap-2">
           <h2 className="text-sm font-medium text-muted-foreground flex items-center gap-1.5 shrink-0">
@@ -306,9 +306,10 @@ export function AnalystPanel() {
           </>
         )}
       </div>
-      <p className="text-[10px] text-muted-foreground/60 text-center mt-3 px-4">
+      <p className="text-[10px] text-muted-foreground/60 text-center mt-3 px-4 shrink-0">
         Conversations are stored to provide context and improve AI performance.
       </p>
     </div>
+    </MobileDrawerPanel>
   )
 }

--- a/components/app-footer.tsx
+++ b/components/app-footer.tsx
@@ -11,9 +11,9 @@ function HemrockIcon({ className }: { className?: string }) {
 
 export function AppFooter() {
   return (
-    <footer className="flex items-center justify-start px-4 md:px-8 pt-2 pb-8 shrink-0">
-      <div className="flex items-center gap-9 text-sm text-muted-foreground border-t pt-3">
-        <span className="flex items-center gap-1.5">
+    <footer className="px-4 md:px-8 pt-2 pb-8 shrink-0">
+      <ul className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-9 text-sm text-muted-foreground border-t pt-3">
+        <li className="flex items-center gap-1.5">
           Made by{' '}
           <a
             href="https://hemrock.com"
@@ -24,40 +24,48 @@ export function AppFooter() {
             <HemrockIcon className="h-3.5 w-3.5" />
             Hemrock
           </a>
-        </span>
-        <a
-          href="https://github.com/tdavidson/reporting"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-1.5 hover:text-foreground transition-colors"
-        >
-          View on <Github className="h-3 w-3" />
-          GitHub
-        </a>
-        <Link
-          href="/license"
-          className="flex items-center gap-1.5 hover:text-foreground transition-colors"
-        >
-          <Scale className="h-3 w-3" />
-          License
-        </Link>
-        <a
-          href="https://www.hemrock.com/terms"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="hover:text-foreground transition-colors"
-        >
-          Terms
-        </a>
-        <a
-          href="https://www.hemrock.com/privacy"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="hover:text-foreground transition-colors"
-        >
-          Privacy
-        </a>
-      </div>
+        </li>
+        <li>
+          <a
+            href="https://github.com/tdavidson/reporting"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1.5 hover:text-foreground transition-colors"
+          >
+            View on <Github className="h-3 w-3" />
+            GitHub
+          </a>
+        </li>
+        <li>
+          <Link
+            href="/license"
+            className="flex items-center gap-1.5 hover:text-foreground transition-colors"
+          >
+            <Scale className="h-3 w-3" />
+            License
+          </Link>
+        </li>
+        <li>
+          <a
+            href="https://www.hemrock.com/terms"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-foreground transition-colors"
+          >
+            Terms
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://www.hemrock.com/privacy"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-foreground transition-colors"
+          >
+            Privacy
+          </a>
+        </li>
+      </ul>
     </footer>
   )
 }

--- a/components/mobile-drawer-panel.tsx
+++ b/components/mobile-drawer-panel.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { Sheet, SheetContent } from '@/components/ui/sheet'
+import { useMediaQuery } from '@/lib/hooks/use-media-query'
+
+interface MobileDrawerPanelProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  children: React.ReactNode
+}
+
+export function MobileDrawerPanel({ open, onOpenChange, children }: MobileDrawerPanelProps) {
+  const isDesktop = useMediaQuery('(min-width: 1024px)')
+
+  if (isDesktop) {
+    if (!open) return null
+    return (
+      <div className="w-[340px] shrink-0 sticky top-4">
+        {children}
+      </div>
+    )
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="p-0 pt-12 w-[340px] max-w-[85vw]">
+        {children}
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/components/portfolio-notes.tsx
+++ b/components/portfolio-notes.tsx
@@ -8,6 +8,7 @@ import { MentionTextarea, type MentionMember, type MentionTextareaRef } from '@/
 import { useAnalystContext } from '@/components/analyst-context'
 import { useFeatureVisibility } from '@/components/feature-visibility-context'
 import Link from 'next/link'
+import { MobileDrawerPanel } from '@/components/mobile-drawer-panel'
 
 interface Note {
   id: string
@@ -92,8 +93,12 @@ export function PortfolioNotesButton() {
 
 export function PortfolioNotesPanel() {
   const ctx = useContext(PortfolioNotesContext)
-  if (!ctx || !ctx.open) return null
-  return <NotesPanel toggle={ctx.toggle} />
+  if (!ctx) return null
+  return (
+    <MobileDrawerPanel open={ctx.open} onOpenChange={(open) => { if (!open) ctx.toggle() }}>
+      <NotesPanel toggle={ctx.toggle} />
+    </MobileDrawerPanel>
+  )
 }
 
 function formatRelativeTime(dateStr: string) {
@@ -240,8 +245,8 @@ function NotesPanel({ toggle }: { toggle: () => void }) {
   }
 
   return (
-    <div className="w-full lg:w-[340px] shrink-0 lg:sticky top-4">
-    <div className="max-h-[80vh] lg:max-h-[calc(100vh-6rem)] rounded-lg border bg-card flex flex-col">
+    <div className="flex flex-col h-full">
+    <div className="max-h-[80vh] lg:max-h-[calc(100vh-6rem)] rounded-lg border bg-card flex flex-col flex-1">
       <div className="px-4 py-3 flex items-center justify-between">
         <h2 className="text-sm font-medium text-muted-foreground">Team Notes</h2>
         <button onClick={toggle}>
@@ -358,7 +363,7 @@ function NotesPanel({ toggle }: { toggle: () => void }) {
         </div>
       </div>
     </div>
-    <p className="text-[10px] text-muted-foreground/60 text-center mt-3 px-4">
+    <p className="text-[10px] text-muted-foreground/60 text-center mt-3 px-4 shrink-0">
       All chat history is saved by {fundName}.
     </p>
     </div>

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,0 +1,8 @@
+import { initBotId } from 'botid/client/core'
+
+initBotId({
+  protect: [
+    { path: '/api/auth/*', method: 'POST' },
+    { path: '/api/demo/seed', method: 'POST' },
+  ],
+})

--- a/lib/demo/seed.ts
+++ b/lib/demo/seed.ts
@@ -389,6 +389,45 @@ const INVESTMENTS: InvestmentDef[] = [
   { companyName: 'Lattis', transaction_type: 'investment', round_name: 'Pre-Seed', transaction_date: '2024-08-15', investment_cost: 250000, shares_acquired: 250000, share_price: 1.00, notes: 'Angel round' },
 ]
 
+type FundCashFlowDef = {
+  portfolio_group: string
+  flow_date: string
+  flow_type: 'commitment' | 'called_capital' | 'distribution'
+  amount: number
+  notes?: string
+}
+
+const FUND_CASH_FLOWS: FundCashFlowDef[] = [
+  // ---------------------------------------------------------------------------
+  // Fund I — $12M commitment, deployed $8.15M across 4 companies
+  //   RouteWise:  Seed $400K (Mar 2022) + Series A $1M (Jul 2023) + Series B $2M (Nov 2024)
+  //   NovaTech:   Seed $500K (Jun 2023) + Series A $1.5M (Sep 2024)
+  //   GreenLeaf:  Seed $750K (Jan 2024)
+  //   AdVantage:  Series A $2M (Jun 2024)
+  // ---------------------------------------------------------------------------
+  { portfolio_group: 'Fund I', flow_date: '2022-01-15', flow_type: 'commitment', amount: 12000000, notes: 'Fund I final close — $12M committed' },
+  { portfolio_group: 'Fund I', flow_date: '2022-03-15', flow_type: 'called_capital', amount: 500000, notes: 'Capital call #1 — RouteWise Seed ($400K) + mgmt fee reserve' },
+  { portfolio_group: 'Fund I', flow_date: '2023-06-10', flow_type: 'called_capital', amount: 1800000, notes: 'Capital call #2 — NovaTech Seed ($500K), RouteWise Series A ($1M), fees' },
+  { portfolio_group: 'Fund I', flow_date: '2024-01-05', flow_type: 'called_capital', amount: 1000000, notes: 'Capital call #3 — GreenLeaf Bio Seed ($750K) + reserves' },
+  { portfolio_group: 'Fund I', flow_date: '2024-06-01', flow_type: 'called_capital', amount: 2500000, notes: 'Capital call #4 — AdVantage Series A ($2M) + reserves' },
+  { portfolio_group: 'Fund I', flow_date: '2024-09-01', flow_type: 'called_capital', amount: 2000000, notes: 'Capital call #5 — NovaTech Series A follow-on ($1.5M) + reserves' },
+  { portfolio_group: 'Fund I', flow_date: '2024-11-01', flow_type: 'called_capital', amount: 2500000, notes: 'Capital call #6 — RouteWise Series B ($2M) + reserves' },
+
+  // ---------------------------------------------------------------------------
+  // Fund II — $10M commitment, deployed $6.7M across 4 companies
+  //   Benchline:  Seed $300K (Jan 2022) + Series A $1.2M (Apr 2023) + Series B $2.5M (Aug 2024)
+  //   TapFin:     Seed $350K (Sep 2023) + Series A $1.5M (Dec 2024)
+  //   Verdant:    Seed $600K (Apr 2024)
+  //   Lattis:     Pre-Seed $250K (Aug 2024)
+  // ---------------------------------------------------------------------------
+  { portfolio_group: 'Fund II', flow_date: '2021-11-01', flow_type: 'commitment', amount: 10000000, notes: 'Fund II final close — $10M committed' },
+  { portfolio_group: 'Fund II', flow_date: '2022-01-10', flow_type: 'called_capital', amount: 500000, notes: 'Capital call #1 — Benchline Seed ($300K) + mgmt fee reserve' },
+  { portfolio_group: 'Fund II', flow_date: '2023-04-01', flow_type: 'called_capital', amount: 1800000, notes: 'Capital call #2 — Benchline Series A ($1.2M), TapFin Seed ($350K), fees' },
+  { portfolio_group: 'Fund II', flow_date: '2024-04-15', flow_type: 'called_capital', amount: 1200000, notes: 'Capital call #3 — Verdant Seed ($600K) + reserves' },
+  { portfolio_group: 'Fund II', flow_date: '2024-08-01', flow_type: 'called_capital', amount: 3200000, notes: 'Capital call #4 — Benchline Series B ($2.5M), Lattis Pre-Seed ($250K), reserves' },
+  { portfolio_group: 'Fund II', flow_date: '2024-12-01', flow_type: 'called_capital', amount: 1800000, notes: 'Capital call #5 — TapFin Series A ($1.5M) + reserves' },
+]
+
 type InteractionDef = {
   companyName: string | null
   type: 'email' | 'intro'
@@ -847,6 +886,20 @@ export async function seedDemoData(adminUserId: string): Promise<boolean> {
       current_share_price: inv.current_share_price ?? null,
       cost_basis_exited: inv.cost_basis_exited ?? null,
       proceeds_received: inv.proceeds_received ?? null,
+    })
+  }
+
+  // -------------------------------------------------------------------------
+  // Fund Cash Flows
+  // -------------------------------------------------------------------------
+  for (const cf of FUND_CASH_FLOWS) {
+    await admin.from('fund_cash_flows' as any).insert({
+      fund_id: fundId,
+      portfolio_group: cf.portfolio_group,
+      flow_date: cf.flow_date,
+      flow_type: cf.flow_type,
+      amount: cf.amount,
+      notes: cf.notes ?? null,
     })
   }
 

--- a/lib/hooks/use-media-query.ts
+++ b/lib/hooks/use-media-query.ts
@@ -1,0 +1,15 @@
+import { useState, useEffect } from 'react'
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false)
+
+  useEffect(() => {
+    const mql = window.matchMedia(query)
+    setMatches(mql.matches)
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches)
+    mql.addEventListener('change', handler)
+    return () => mql.removeEventListener('change', handler)
+  }, [query])
+
+  return matches
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,5 @@
+import { withBotId } from 'botid/next/config'
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   async headers() {
@@ -34,4 +36,4 @@ const nextConfig = {
     ]
   },
 }
-export default nextConfig
+export default withBotId(nextConfig)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reporting",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reporting",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
         "@google/genai": "^1.44.0",
@@ -22,6 +22,7 @@
         "@supabase/supabase-js": "^2",
         "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^1.3.1",
+        "botid": "^1.5.11",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "docx": "^9.6.0",
@@ -3439,6 +3440,23 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
       "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
       "license": "MIT"
+    },
+    "node_modules/botid": {
+      "version": "1.5.11",
+      "resolved": "https://registry.npmjs.org/botid/-/botid-1.5.11.tgz",
+      "integrity": "sha512-KOO1A3+/vFVJk5aFoG3sNwiogKFPVR+x4aw4gQ1b2e0XoE+i5xp48/EZn+WqR07jRHeDGwHWQUOtV5WVm7xiww==",
+      "peerDependencies": {
+        "next": "*",
+        "react": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@supabase/supabase-js": "^2",
     "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",
+    "botid": "^1.5.11",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "docx": "^9.6.0",


### PR DESCRIPTION
- Seed: Add fund-level cash flows for Fund I ($12M commitment, 7 capital calls)
  and Fund II ($10M commitment, 6 capital calls) aligned with investment dates
- Footer: Convert to vertical list on mobile (flex-col) to prevent horizontal
  overflow, switch to sm:flex-row for wider screens
- BotID: Install botid package, wrap next.config with withBotId(), add
  instrumentation-client.ts protecting auth and demo seed endpoints
- Notes/Analyst panels: Wrap in MobileDrawerPanel that renders as a right-side
  Sheet drawer on mobile (<lg) and inline sticky panel on desktop (lg+)
- Add useMediaQuery hook and MobileDrawerPanel reusable component

https://claude.ai/code/session_013CcJPb2W4Dy81g4RVSwgFf