### PR TITLE
Add /funds/[id] fund detail page as the lead page for a vehicle

### DIFF
--- a/app/(app)/funds/[id]/fund-detail-view.tsx
+++ b/app/(app)/funds/[id]/fund-detail-view.tsx
@@ -1,0 +1,444 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import {
+  ResponsiveContainer, ComposedChart, BarChart, Bar, Line, XAxis, YAxis,
+  CartesianGrid, Tooltip, Legend, PieChart, Pie, Cell,
+} from 'recharts'
+import { Loader2, Gauge, ArrowRight } from 'lucide-react'
+import { useCurrency, formatCurrency, formatCurrencyFull } from '@/components/currency-context'
+import { useVehicle } from '@/components/accounting-vehicle'
+import { AnalystToggleButton } from '@/components/analyst-button'
+import { Card, CardContent } from '@/components/ui/card'
+
+// The fund detail (lead) page. Everything here is READ-ONLY and derived — the same numbers as the
+// /funds overview (fund-economics), the schedule of investments (statements), and the growth
+// series (fund-timeseries). Operational admin lives on /funds/status.
+
+interface Metrics {
+  committed: number; paidIn: number; uncalled: number; distributions: number
+  nav: number; totalValue: number
+  dpi: number | null; rvpi: number | null; tvpi: number | null; irr: number | null
+}
+interface VehicleEconomics {
+  vehicle: string; vintageYear: number | null; source: 'ledger' | 'events'; lpCount: number
+  fund: Metrics; lp: Metrics; gp?: Metrics; carryAccrued?: number
+}
+interface SoiGroup { name: string; cost: number; fairValue: number; pctOfNetAssets: number }
+interface SoiRow { name: string; cost: number; fairValue: number; pctOfNetAssets: number; moic?: number | null; industry?: string | null }
+interface Soi {
+  rows: SoiRow[]; totalCost: number; totalFairValue: number; netAssets: number
+  source: 'tracker' | 'ledger'; byIndustry: SoiGroup[]; byGeography: SoiGroup[]; byAssetType: SoiGroup[]
+}
+interface TsPoint {
+  period: string; label: string
+  calledCapital: number; distributed: number
+  contributions: number; distributions: number; operatingIncome: number
+  realizedGains: number; unrealizedGains: number; expenses: number; other: number; nav: number
+  investedCapital: number; proceeds: number; portfolioValue: number
+}
+interface Timeseries { points: TsPoint[]; hasGross: boolean }
+
+type Lens = 'lp' | 'fund'
+
+// Categorical hues, assigned in FIXED order from the theme's chart ramp (never cycled).
+const HUE = {
+  chart1: 'hsl(var(--chart-1))',
+  chart2: 'hsl(var(--chart-2))',
+  chart3: 'hsl(var(--chart-3))',
+  chart4: 'hsl(var(--chart-4))',
+  chart5: 'hsl(var(--chart-5))',
+  ink: 'hsl(var(--foreground))',
+  muted: 'hsl(var(--muted-foreground))',
+  surface: 'hsl(var(--background))',
+}
+// A fixed palette for the SOI breakdown slices, so a slice keeps its colour as the mix changes.
+const SLICE = [HUE.chart2, HUE.chart1, HUE.chart3, HUE.chart4, HUE.chart5, HUE.muted]
+
+const moic = (v: number | null | undefined) => (v == null ? '—' : `${v.toFixed(2)}x`)
+const irrPct = (v: number | null | undefined) => {
+  if (v == null) return '—'
+  const p = v * 100
+  return `${(Object.is(p, -0) ? 0 : p).toFixed(1)}%`
+}
+
+export function FundDetailView({ vehicle }: { vehicle: string }) {
+  const currency = useCurrency()
+  const fmt = (v: number) => formatCurrency(v, currency)
+  const fmtFull = (v: number) => formatCurrencyFull(v, currency)
+  const { setGroup } = useVehicle()
+
+  const [econ, setEcon] = useState<VehicleEconomics | null>(null)
+  const [soi, setSoi] = useState<Soi | null>(null)
+  const [ts, setTs] = useState<Timeseries | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [notFound, setNotFound] = useState(false)
+  const [lens, setLens] = useState<Lens>('lp')
+
+  // Pin the section's vehicle context to this URL, so the Analyst and any subpage the user opens
+  // from here (Admin, capital accounts, …) inherit the fund they're looking at.
+  useEffect(() => { setGroup(vehicle) }, [vehicle, setGroup])
+
+  const g = `group=${encodeURIComponent(vehicle)}`
+  const load = useCallback(() => {
+    setLoading(true)
+    Promise.all([
+      fetch('/api/accounting/fund-economics').then(r => (r.ok ? r.json() : { vehicles: [] })),
+      fetch(`/api/accounting/statements?${g}&preset=itd`).then(r => (r.ok ? r.json() : null)),
+      fetch(`/api/accounting/fund-timeseries?${g}`).then(r => (r.ok ? r.json() : null)),
+    ]).then(([e, s, t]) => {
+      const found = (e.vehicles ?? []).find((v: VehicleEconomics) => v.vehicle === vehicle) ?? null
+      setEcon(found)
+      setNotFound(!found)
+      setSoi(s?.scheduleOfInvestments ?? null)
+      setTs(t && !t.error ? t : null)
+    }).finally(() => setLoading(false))
+  }, [g, vehicle])
+  useEffect(() => { load() }, [load])
+
+  const hasGpSplit = !!econ && ((econ.gp?.paidIn ?? 0) !== 0 || (econ.gp?.nav ?? 0) !== 0 || (econ.carryAccrued ?? 0) !== 0)
+  const effectiveLens: Lens = hasGpSplit ? lens : 'fund'
+  const m = econ ? (effectiveLens === 'lp' ? econ.lp : econ.fund) : null
+
+  if (loading) {
+    return (
+      <div className="rounded-lg border p-6 flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" /> Loading fund detail…
+      </div>
+    )
+  }
+  if (notFound || !econ || !m) {
+    return (
+      <div className="rounded-lg border p-6 space-y-3 max-w-lg">
+        <p className="text-sm">No vehicle named <strong>{vehicle}</strong> was found, or it carries no capital yet.</p>
+        <Link href="/funds" className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-accent transition-colors">
+          Back to all funds <ArrowRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header — name, provenance, and the jump to the admin page. */}
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div className="space-y-1 min-w-0">
+          <h1 className="text-2xl font-semibold tracking-tight truncate" title={vehicle}>{vehicle}</h1>
+          <p className="text-sm text-muted-foreground">
+            {econ.vintageYear ? <>Vintage {econ.vintageYear} · </> : null}
+            {econ.source === 'ledger' ? 'Fund accounting' : 'LP capital tracking'} · {econ.lpCount} {econ.lpCount === 1 ? 'partner' : 'partners'}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {hasGpSplit && (
+            <div className="inline-flex rounded-md border p-0.5 text-xs">
+              {(['lp', 'fund'] as Lens[]).map(l => (
+                <button
+                  key={l}
+                  onClick={() => setLens(l)}
+                  className={`px-2 py-1 rounded ${lens === l ? 'bg-muted font-medium' : 'text-muted-foreground'}`}
+                >
+                  {l === 'lp' ? 'Net to LP' : 'Whole fund'}
+                </button>
+              ))}
+            </div>
+          )}
+          <Link
+            href="/funds/status"
+            className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-accent transition-colors"
+          >
+            <Gauge className="h-3.5 w-3.5" /> Admin
+          </Link>
+          {/* The chrome's Analyst toggle steps aside for the detail route (it owns its layout), so
+              the toggle rides here instead — same top-right placement as every accounting page. */}
+          <AnalystToggleButton />
+        </div>
+      </div>
+
+      {/* Key metrics — same Card treatment as the /funds overview and the LP snapshot. */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <MetricBox label="Committed" value={fmt(m.committed)} />
+        <MetricBox label="Called" value={fmt(m.paidIn)} />
+        <MetricBox label="Uncalled" value={fmt(m.uncalled)} />
+        <MetricBox label="Distributed" value={fmt(m.distributions)} />
+        <MetricBox label="NAV" value={fmt(m.nav)} />
+        <MetricBox label="TVPI" value={moic(m.tvpi)} />
+        <MetricBox label="DPI" value={moic(m.dpi)} />
+        <MetricBox label="IRR" value={irrPct(m.irr)} />
+      </div>
+
+      {/* Growth over time — two full-width charts. */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <FundGrowthChart points={ts?.points ?? []} hasGross={!!ts?.hasGross} fmt={fmt} fmtFull={fmtFull} />
+        <NavCompositionChart points={ts?.points ?? []} fmt={fmt} fmtFull={fmtFull} />
+      </div>
+
+      {/* Investment breakdown — from the schedule of investments (tracker rows). */}
+      {soi && soi.source === 'tracker' && soi.rows.length > 0 ? (
+        <div className="grid gap-4 lg:grid-cols-2">
+          <BreakdownChart title="By industry" groups={soi.byIndustry} fmt={fmt} fmtFull={fmtFull} />
+          <BreakdownChart
+            title={soi.byAssetType.length > 1 ? 'By asset type' : 'By geography'}
+            groups={soi.byAssetType.length > 1 ? soi.byAssetType : soi.byGeography}
+            fmt={fmt}
+            fmtFull={fmtFull}
+          />
+          <div className="lg:col-span-2">
+            <TopHoldings rows={soi.rows} totalFairValue={soi.totalFairValue} fmt={fmt} fmtFull={fmtFull} />
+          </div>
+        </div>
+      ) : (
+        <ChartCard title="Investments">
+          <div className="flex h-[220px] items-center justify-center text-center text-sm text-muted-foreground px-6">
+            No per-company investment detail is tracked for this vehicle yet. Record holdings on the{' '}
+            <Link href="/funds/schedule-of-investments" className="underline underline-offset-2 hover:text-foreground mx-1">
+              schedule of investments
+            </Link>{' '}
+            and they&rsquo;ll break down here.
+          </div>
+        </ChartCard>
+      )}
+
+      <p className="text-xs text-muted-foreground max-w-3xl">
+        Every figure is derived — the metrics from the capital accounts (the same numbers as the funds overview),
+        the breakdown from the schedule of investments, and the growth charts from the dated ledger and portfolio
+        history. The growth charts are whole-fund; the metric lens above scopes only the boxes.
+      </p>
+    </div>
+  )
+}
+
+// ── Shared pieces ───────────────────────────────────────────────────────────
+
+function MetricBox({ label, value }: { label: string; value: string }) {
+  return (
+    <Card>
+      <CardContent className="pt-4 pb-3 px-4">
+        <p className="text-xs text-muted-foreground mb-1">{label}</p>
+        <p className="text-xl font-semibold">{value}</p>
+      </CardContent>
+    </Card>
+  )
+}
+
+function ChartCard({ title, action, children }: { title: string; action?: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <Card>
+      <CardContent className="pt-4 pb-4 px-4">
+        <div className="flex items-center justify-between gap-2 mb-3">
+          <p className="text-sm font-medium">{title}</p>
+          {action}
+        </div>
+        {children}
+      </CardContent>
+    </Card>
+  )
+}
+
+const AXIS = { fontSize: 11 } as const
+const tooltipStyle = {
+  borderRadius: '6px',
+  border: '1px solid hsl(var(--border))',
+  backgroundColor: 'hsl(var(--popover))',
+  color: 'hsl(var(--popover-foreground))',
+  fontSize: '12px',
+} as const
+
+function EmptyPlot({ label }: { label: string }) {
+  return <div className="flex h-[240px] items-center justify-center text-sm text-muted-foreground">{label}</div>
+}
+
+// ── Fund growth over time: stacked bars, toggle gross ⇄ net ───────────────────
+
+function FundGrowthChart({
+  points, hasGross, fmt, fmtFull,
+}: { points: TsPoint[]; hasGross: boolean; fmt: (v: number) => string; fmtFull: (v: number) => string }) {
+  const [mode, setMode] = useState<'net' | 'gross'>('net')
+  const view = hasGross ? mode : 'net'
+
+  const toggle = hasGross ? (
+    <div className="inline-flex rounded-md border p-0.5 text-xs">
+      {(['net', 'gross'] as const).map(mo => (
+        <button
+          key={mo}
+          onClick={() => setMode(mo)}
+          className={`px-2 py-1 rounded ${mode === mo ? 'bg-muted font-medium' : 'text-muted-foreground'}`}
+        >
+          {mo === 'net' ? 'Called & distributed' : 'Invested & proceeds'}
+        </button>
+      ))}
+    </div>
+  ) : undefined
+
+  // Called capital and distributions are the LP-cash view; invested capital and proceeds are the
+  // deal-level (gross) view of the same fund. Distinct series → distinct fixed hues.
+  const series = view === 'net'
+    ? [
+        { key: 'calledCapital', name: 'Called capital', color: HUE.chart3 },
+        { key: 'distributed', name: 'Distributed', color: HUE.chart2 },
+      ]
+    : [
+        { key: 'investedCapital', name: 'Invested capital', color: HUE.chart1 },
+        { key: 'proceeds', name: 'Proceeds', color: HUE.chart4 },
+      ]
+
+  return (
+    <ChartCard title="Fund growth over time" action={toggle}>
+      {points.length === 0 ? (
+        <EmptyPlot label="No dated activity yet." />
+      ) : (
+        <ResponsiveContainer width="100%" height={260}>
+          <BarChart data={points} margin={{ top: 8, right: 8, bottom: 0, left: 8 }}>
+            <CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-border" />
+            <XAxis dataKey="label" tick={AXIS} tickLine={false} axisLine={false} interval="equidistantPreserveStart" className="text-muted-foreground" />
+            <YAxis tick={AXIS} tickLine={false} axisLine={false} width={52} tickFormatter={fmt} className="text-muted-foreground" />
+            <Tooltip cursor={{ fill: 'hsl(var(--muted) / 0.4)' }} contentStyle={tooltipStyle} formatter={(v: any, n: any) => [fmtFull(v as number), n]} />
+            <Legend wrapperStyle={{ fontSize: 12 }} iconType="circle" />
+            {series.map((s, i) => (
+              <Bar
+                key={s.key}
+                dataKey={s.key}
+                name={s.name}
+                stackId="a"
+                fill={s.color}
+                stroke={HUE.surface}
+                strokeWidth={1}
+                radius={i === series.length - 1 ? [3, 3, 0, 0] : undefined}
+              />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </ChartCard>
+  )
+}
+
+// ── NAV growth over time: stacked composition + NAV total line ────────────────
+
+const NAV_SERIES = [
+  { key: 'netPaidIn', name: 'Net paid-in capital', color: HUE.chart3 },
+  { key: 'realizedGains', name: 'Realized gains', color: HUE.chart2 },
+  { key: 'unrealizedGains', name: 'Unrealized gains', color: HUE.chart1 },
+  { key: 'operatingIncome', name: 'Operating income', color: HUE.chart5 },
+  { key: 'expenses', name: 'Expenses & fees', color: HUE.chart4 },
+  { key: 'other', name: 'Other', color: HUE.muted },
+] as const
+
+function NavCompositionChart({
+  points, fmt, fmtFull,
+}: { points: TsPoint[]; fmt: (v: number) => string; fmtFull: (v: number) => string }) {
+  // Net paid-in = contributions net of capital returned. The rest of the composition (gains,
+  // income, expenses) is already signed so the stack sums to NAV, which the overlaid line traces.
+  const data = useMemo(
+    () => points.map(p => ({ ...p, netPaidIn: Math.round((p.contributions + p.distributions) * 100) / 100 })),
+    [points],
+  )
+  const shown = NAV_SERIES.filter(s => data.some(d => Math.abs(Number((d as any)[s.key])) > 0.5))
+
+  return (
+    <ChartCard title="NAV growth over time">
+      {points.length === 0 ? (
+        <EmptyPlot label="No dated activity yet." />
+      ) : (
+        <ResponsiveContainer width="100%" height={260}>
+          <ComposedChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: 8 }} stackOffset="sign">
+            <CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-border" />
+            <XAxis dataKey="label" tick={AXIS} tickLine={false} axisLine={false} interval="equidistantPreserveStart" className="text-muted-foreground" />
+            <YAxis tick={AXIS} tickLine={false} axisLine={false} width={52} tickFormatter={fmt} className="text-muted-foreground" />
+            <Tooltip cursor={{ fill: 'hsl(var(--muted) / 0.4)' }} contentStyle={tooltipStyle} formatter={(v: any, n: any) => [fmtFull(v as number), n]} />
+            <Legend wrapperStyle={{ fontSize: 12 }} iconType="circle" />
+            {shown.map(s => (
+              <Bar key={s.key} dataKey={s.key} name={s.name} stackId="nav" fill={s.color} stroke={HUE.surface} strokeWidth={1} />
+            ))}
+            {/* Total NAV traced in ink, not a series colour — it's a reference, not a category. */}
+            <Line type="monotone" dataKey="nav" name="NAV" stroke={HUE.ink} strokeWidth={2} dot={false} />
+          </ComposedChart>
+        </ResponsiveContainer>
+      )}
+    </ChartCard>
+  )
+}
+
+// ── Investment breakdown: donut by a dimension ────────────────────────────────
+
+function BreakdownChart({
+  title, groups, fmt, fmtFull,
+}: { title: string; groups: SoiGroup[]; fmt: (v: number) => string; fmtFull: (v: number) => string }) {
+  // Cap the legend: keep the top 5 slices by fair value, fold the tail into "Other".
+  const data = useMemo(() => {
+    const sorted = [...groups].filter(g => g.fairValue > 0).sort((a, b) => b.fairValue - a.fairValue)
+    if (sorted.length <= 6) return sorted
+    const head = sorted.slice(0, 5)
+    const tail = sorted.slice(5).reduce((s, g) => s + g.fairValue, 0)
+    return [...head, { name: 'Other', cost: 0, fairValue: tail, pctOfNetAssets: 0 }]
+  }, [groups])
+  const total = data.reduce((s, g) => s + g.fairValue, 0)
+
+  return (
+    <ChartCard title={title}>
+      {data.length === 0 ? (
+        <EmptyPlot label="Nothing to break down." />
+      ) : (
+        <div className="flex items-center gap-4">
+          <ResponsiveContainer width="55%" height={220}>
+            <PieChart>
+              <Pie data={data} dataKey="fairValue" nameKey="name" cx="50%" cy="50%" innerRadius={48} outerRadius={80} paddingAngle={2} stroke={HUE.surface} strokeWidth={2}>
+                {data.map((_, i) => <Cell key={i} fill={SLICE[i % SLICE.length]} />)}
+              </Pie>
+              <Tooltip contentStyle={tooltipStyle} formatter={(v: any, n: any) => [fmtFull(v as number), n]} />
+            </PieChart>
+          </ResponsiveContainer>
+          {/* Direct-labelled legend — identity + magnitude beside each swatch, in ink. */}
+          <ul className="flex-1 space-y-1.5 text-xs min-w-0">
+            {data.map((gp, i) => (
+              <li key={gp.name} className="flex items-center gap-2">
+                <span className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ background: SLICE[i % SLICE.length] }} />
+                <span className="truncate flex-1" title={gp.name}>{gp.name}</span>
+                <span className="font-mono text-muted-foreground shrink-0">{fmt(gp.fairValue)}</span>
+                <span className="font-mono text-muted-foreground/70 shrink-0 w-10 text-right">
+                  {total ? `${Math.round((gp.fairValue / total) * 100)}%` : '—'}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </ChartCard>
+  )
+}
+
+// ── Top holdings — horizontal magnitude bars ──────────────────────────────────
+
+function TopHoldings({
+  rows, totalFairValue, fmt, fmtFull,
+}: { rows: SoiRow[]; totalFairValue: number; fmt: (v: number) => string; fmtFull: (v: number) => string }) {
+  const top = [...rows].filter(r => r.fairValue > 0).sort((a, b) => b.fairValue - a.fairValue).slice(0, 8)
+  const max = top.reduce((mx, r) => Math.max(mx, r.fairValue), 0)
+  if (top.length === 0) return null
+
+  return (
+    <ChartCard title="Largest holdings">
+      <div className="space-y-2">
+        {top.map(r => (
+          <div key={r.name} className="flex items-center gap-3 text-sm">
+            <div className="w-40 shrink-0 truncate" title={r.name}>{r.name}</div>
+            <div className="flex-1 min-w-0">
+              <div className="h-4 rounded-sm bg-muted/50 overflow-hidden">
+                <div
+                  className="h-full rounded-sm"
+                  style={{ width: max ? `${Math.max(2, (r.fairValue / max) * 100)}%` : '0%', background: HUE.chart2 }}
+                />
+              </div>
+            </div>
+            <div className="w-20 shrink-0 text-right font-mono" title={fmtFull(r.fairValue)}>{fmt(r.fairValue)}</div>
+            <div className="w-12 shrink-0 text-right font-mono text-muted-foreground">{r.moic == null ? '—' : `${r.moic.toFixed(1)}x`}</div>
+            <div className="w-12 shrink-0 text-right font-mono text-muted-foreground/70">
+              {totalFairValue ? `${Math.round((r.fairValue / totalFairValue) * 100)}%` : '—'}
+            </div>
+          </div>
+        ))}
+      </div>
+    </ChartCard>
+  )
+}

--- a/app/(app)/funds/[id]/page.tsx
+++ b/app/(app)/funds/[id]/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { ArrowLeft } from 'lucide-react'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { vehicleNameById } from '@/lib/accounting/vehicle-id'
 import { requireAccountingAccess } from '../guard'
 import { AccountingBody } from '@/components/accounting-chrome'
 import { FundDetailView } from './fund-detail-view'
@@ -16,14 +18,19 @@ export const metadata: Metadata = { title: 'Fund' }
  * The operational admin — onboarding, the close, the health check, allocation settings — stays on
  * `/funds/status`, which this page links to.
  *
- * `[id]` is the vehicle NAME (portfolio_group), URL-encoded — the whole Accounting section keys on
- * the name, not a surrogate id (see components/accounting-vehicle.tsx). Like `/funds`, this page
- * owns its own layout: AccountingChrome steps aside for it (isFundDetailPath), so there is no
- * vehicle-selector bar — the URL pins the vehicle.
+ * `[id]` is the vehicle's stable `fund_vehicles.id` (a UUID), the same way companies and LPs are
+ * addressed — routing on the id survives a rename and sidesteps names with slashes. We resolve it
+ * to the name here and hand the client the name, because the accounting data still keys on the
+ * portfolio_group string. A legacy vehicle with no registry row is addressed by its name directly,
+ * so an un-migrated fund still works. Like `/funds`, this page owns its layout: AccountingChrome
+ * steps aside (isFundDetailPath), so there is no vehicle-selector bar — the URL pins the vehicle.
  */
 export default async function FundDetailPage({ params }: { params: { id: string } }) {
-  await requireAccountingAccess()
-  const vehicle = decodeURIComponent(params.id)
+  const { fundId } = await requireAccountingAccess()
+  const raw = decodeURIComponent(params.id)
+  // UUID → current name. Falls back to treating the param as the name itself, for legacy vehicles
+  // that exist only as a portfolio_group string (no registry id to route on).
+  const vehicle = (await vehicleNameById(createAdminClient(), fundId, raw)) ?? raw
 
   return (
     <div className="pt-4 md:pt-8 pb-8 w-full">

--- a/app/(app)/funds/[id]/page.tsx
+++ b/app/(app)/funds/[id]/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { requireAccountingAccess } from '../guard'
+import { AccountingBody } from '@/components/accounting-chrome'
+import { FundDetailView } from './fund-detail-view'
+
+export const metadata: Metadata = { title: 'Fund' }
+
+/**
+ * The fund detail page — the LEAD page for a single vehicle.
+ *
+ * `/funds` is the whole-fund overview (every vehicle in one table); this is where a vehicle row
+ * on it now leads. It carries the vehicle's key metrics (same box style as the overview and the
+ * LP snapshot), the schedule-of-investments breakdown, and the growth / NAV-composition charts.
+ * The operational admin — onboarding, the close, the health check, allocation settings — stays on
+ * `/funds/status`, which this page links to.
+ *
+ * `[id]` is the vehicle NAME (portfolio_group), URL-encoded — the whole Accounting section keys on
+ * the name, not a surrogate id (see components/accounting-vehicle.tsx). Like `/funds`, this page
+ * owns its own layout: AccountingChrome steps aside for it (isFundDetailPath), so there is no
+ * vehicle-selector bar — the URL pins the vehicle.
+ */
+export default async function FundDetailPage({ params }: { params: { id: string } }) {
+  await requireAccountingAccess()
+  const vehicle = decodeURIComponent(params.id)
+
+  return (
+    <div className="pt-4 md:pt-8 pb-8 w-full">
+      <Link href="/funds" className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground mb-4">
+        <ArrowLeft className="h-3.5 w-3.5" />All funds
+      </Link>
+      <AccountingBody>
+        <FundDetailView vehicle={vehicle} />
+      </AccountingBody>
+    </div>
+  )
+}

--- a/app/(app)/funds/fund-overview.tsx
+++ b/app/(app)/funds/fund-overview.tsx
@@ -27,6 +27,8 @@ interface Metrics {
 }
 interface Vehicle {
   vehicle: string
+  /** Stable registry id — the detail page routes on it. Null for legacy portfolio_group-only vehicles. */
+  id: string | null
   vintageYear: number | null
   source: 'ledger' | 'events'
   lpCount: number
@@ -56,7 +58,12 @@ export function FundOverview() {
 
   // Clicking a vehicle selects it (localStorage-backed context the whole section reads) and opens
   // its detail page — the lead page for the fund. Admin (/funds/status) is reached from there.
-  const openVehicle = (vehicle: string) => { setGroup(vehicle); router.push(`/funds/${encodeURIComponent(vehicle)}`) }
+  // Route on the stable id (like companies and LPs); a legacy vehicle without one falls back to
+  // its name, which the detail page resolves the same way.
+  const openVehicle = (v: Vehicle) => {
+    setGroup(v.vehicle)
+    router.push(`/funds/${v.id ?? encodeURIComponent(v.vehicle)}`)
+  }
 
   const [vehicles, setVehicles] = useState<Vehicle[]>([])
   const [loading, setLoading] = useState(true)
@@ -218,7 +225,7 @@ export function FundOverview() {
               return (
                 <tr key={v.vehicle} className="border-t hover:bg-muted/30">
                   <td className="px-3 py-2 font-medium">
-                    <button onClick={() => openVehicle(v.vehicle)} title={v.vehicle} className="text-left hover:underline hover:text-foreground truncate max-w-[220px] block">
+                    <button onClick={() => openVehicle(v)} title={v.vehicle} className="text-left hover:underline hover:text-foreground truncate max-w-[220px] block">
                       {v.vehicle}
                     </button>
                   </td>
@@ -313,10 +320,10 @@ function OnboardingEmptyState() {
         <p className="text-xs text-muted-foreground">Two ways in:</p>
         <div className="flex flex-wrap gap-2">
           <Link
-            href="/funds/status"
+            href="/settings"
             className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-accent transition-colors"
           >
-            Set up a vehicle
+            Add a vehicle
             <ArrowRight className="h-3.5 w-3.5" />
           </Link>
           <Link

--- a/app/(app)/funds/fund-overview.tsx
+++ b/app/(app)/funds/fund-overview.tsx
@@ -54,9 +54,9 @@ export function FundOverview() {
   const router = useRouter()
   const { setGroup } = useVehicle()
 
-  // Clicking a vehicle selects it (localStorage-backed context the whole section reads) and
-  // jumps to its status page — which then loads scoped to that vehicle.
-  const openVehicle = (vehicle: string) => { setGroup(vehicle); router.push('/funds/status') }
+  // Clicking a vehicle selects it (localStorage-backed context the whole section reads) and opens
+  // its detail page — the lead page for the fund. Admin (/funds/status) is reached from there.
+  const openVehicle = (vehicle: string) => { setGroup(vehicle); router.push(`/funds/${encodeURIComponent(vehicle)}`) }
 
   const [vehicles, setVehicles] = useState<Vehicle[]>([])
   const [loading, setLoading] = useState(true)

--- a/app/api/accounting/fund-timeseries/route.ts
+++ b/app/api/accounting/fund-timeseries/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+// accounting domain (lib/access/route-domains.ts). The middleware has already checked the caller's
+// grant for this route + method; this resolves identity and keeps the demo out of writes.
+import { assertReadAccess } from '@/lib/api-helpers'
+import { resolveGroupOr400 } from '@/lib/accounting/http-vehicle'
+import { fundTimeseries } from '@/lib/accounting/fund-timeseries'
+
+// GET — whole-fund growth over time for one vehicle: the quarterly cumulative series behind the
+// fund detail page's growth and NAV-composition charts. Whole-fund, so no gp_economics carve-out
+// is needed — the carry/transfer reallocations net to zero across every partner.
+export async function GET(req: NextRequest) {
+  const supabase = createClient()
+  const admin = createAdminClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const gate = await assertReadAccess(admin, user.id)
+  if (gate instanceof NextResponse) return gate
+  const group = await resolveGroupOr400(admin, gate.fundId, req.nextUrl.searchParams.get('group'))
+  if (group instanceof NextResponse) return group
+
+  const asOf = req.nextUrl.searchParams.get('asOf') ?? undefined
+  if (asOf && !/^\d{4}-\d{2}-\d{2}$/.test(asOf)) {
+    return NextResponse.json({ error: 'asOf must be YYYY-MM-DD' }, { status: 400 })
+  }
+
+  try {
+    const series = await fundTimeseries(admin, gate.fundId, group, asOf)
+    return NextResponse.json(series)
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : 'Failed' }, { status: 500 })
+  }
+}

--- a/components/accounting-chrome.tsx
+++ b/components/accounting-chrome.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { usePathname } from 'next/navigation'
-import { VehicleBar } from '@/components/accounting-vehicle'
+import { VehicleBar, isFundDetailPath } from '@/components/accounting-vehicle'
 import { AnalystToggleButton } from '@/components/analyst-button'
 import { AnalystPanel } from '@/components/analyst-panel'
 
@@ -26,8 +26,10 @@ import { AnalystPanel } from '@/components/analyst-panel'
 export function AccountingChrome({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
 
-  // /funds owns its whole layout (see AccountingPageHeader + AccountingBody in its page).
-  if (pathname === '/funds') return <>{children}</>
+  // /funds and the fund detail page (/funds/[id]) own their whole layout — title all the way up,
+  // Analyst panel below (see AccountingPageHeader + AccountingBody in their pages). No vehicle bar:
+  // the overview spans every vehicle, and the detail page is pinned to one by its URL.
+  if (pathname === '/funds' || isFundDetailPath(pathname)) return <>{children}</>
 
   return (
     <>

--- a/components/accounting-vehicle.tsx
+++ b/components/accounting-vehicle.tsx
@@ -2,7 +2,8 @@
 
 import { createContext, useCallback, useContext, useEffect, useState } from 'react'
 import { usePathname } from 'next/navigation'
-import { Plus } from 'lucide-react'
+import Link from 'next/link'
+import { Settings2 } from 'lucide-react'
 
 interface VehicleCtx {
   group: string | null
@@ -68,7 +69,7 @@ export function useLedgerFetch() {
   )
 }
 
-/** Vehicle selector (+ quick create) shown across the Accounting section. */
+/** Vehicle selector shown across the Accounting section. */
 export function VehicleBar() {
   // The /funds landing page is the fund overview — it spans every vehicle and the selector
   // drives nothing on it, so it would just be a confusing no-op control. The subpages
@@ -77,11 +78,6 @@ export function VehicleBar() {
   const pathname = usePathname()
   const { group, setGroup } = useVehicle()
   const [vehicles, setVehicles] = useState<string[]>([])
-  const [creating, setCreating] = useState(false)
-  const [newName, setNewName] = useState('')
-  const [newKind, setNewKind] = useState('fund')
-  const [busy, setBusy] = useState(false)
-  const [error, setError] = useState<string | null>(null)
 
   const load = useCallback(() => {
     fetch('/api/accounting/vehicles').then(r => (r.ok ? r.json() : [])).then(v => setVehicles(Array.isArray(v) ? v : []))
@@ -93,31 +89,21 @@ export function VehicleBar() {
     if (!group && vehicles.length > 0) setGroup(vehicles[0])
   }, [vehicles, group, setGroup])
 
-  async function create() {
-    const name = newName.trim()
-    if (!name) return
-    setBusy(true); setError(null)
-    const res = await fetch('/api/vehicles', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name, kind: newKind }) })
-    setBusy(false)
-    if (res.ok) {
-      setCreating(false); setNewName(''); setNewKind('fund')
-      load()
-      setGroup(name) // select the new vehicle
-    } else {
-      setError((await res.json().catch(() => ({}))).error ?? 'Could not create vehicle')
-    }
-  }
-
   const current = group ?? (vehicles[0] ?? '')
 
   if (pathname === '/funds') return null
 
+  // Creating and configuring a vehicle (name, kind, vintage, associate links) is an infrequent,
+  // multi-field setup, so it lives in one place — Settings → Investment vehicles — rather than as a
+  // quick-add here that only captured a name and kind. This bar just selects among what exists.
   return (
     <div className="text-sm">
       <div className="flex flex-wrap items-center gap-2">
         <span className="text-muted-foreground">Vehicle</span>
         {vehicles.length === 0 ? (
-          <span className="italic text-muted-foreground">none yet</span>
+          <Link href="/settings" className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground underline underline-offset-2">
+            <Settings2 className="h-3 w-3" />Add one in Settings
+          </Link>
         ) : vehicles.length === 1 ? (
           <span className="font-medium">{current}</span>
         ) : (
@@ -125,31 +111,7 @@ export function VehicleBar() {
             {vehicles.map(v => <option key={v} value={v}>{v}</option>)}
           </select>
         )}
-        {!creating && (
-          <button onClick={() => setCreating(true)} className="inline-flex items-center gap-1 rounded-md border border-input px-2.5 py-1 text-xs hover:bg-accent transition-colors"><Plus className="h-3 w-3" />New vehicle</button>
-        )}
       </div>
-
-      {creating && (
-        <div className="mt-2 flex flex-wrap items-center gap-2">
-          <input
-            autoFocus value={newName} onChange={e => setNewName(e.target.value)}
-            onKeyDown={e => { if (e.key === 'Enter') create(); if (e.key === 'Escape') { setCreating(false); setError(null) } }}
-            placeholder="Vehicle name (e.g. Fund IV, LP)"
-            className="min-w-[220px] rounded border border-input bg-transparent px-2 py-1 text-sm"
-          />
-          <select value={newKind} onChange={e => setNewKind(e.target.value)} className="rounded border border-input bg-transparent px-2 py-1 text-sm">
-            <option value="fund">Fund</option>
-            <option value="spv">SPV</option>
-            <option value="direct">Direct</option>
-            <option value="associate">Associate</option>
-            <option value="other">Other</option>
-          </select>
-          <button onClick={create} disabled={busy || !newName.trim()} className="rounded border px-2 py-1 text-xs hover:bg-accent disabled:opacity-50">{busy ? 'Adding…' : 'Add'}</button>
-          <button onClick={() => { setCreating(false); setError(null) }} className="text-xs text-muted-foreground hover:text-foreground">Cancel</button>
-          {error && <span className="text-xs text-destructive">{error}</span>}
-        </div>
-      )}
     </div>
   )
 }

--- a/components/accounting-vehicle.tsx
+++ b/components/accounting-vehicle.tsx
@@ -31,6 +31,20 @@ export function useVehicle() {
   return useContext(VehicleContext)
 }
 
+// The static `/funds/*` subpages. Anything else of the shape `/funds/<segment>` is the fund
+// DETAIL page (`/funds/[id]`), which — like the `/funds` overview — owns its own header layout
+// and drives the vehicle from its URL rather than from the selector bar.
+const FUND_SUBPAGES = new Set([
+  'status', 'bank', 'journal', 'periods', 'statements', 'capital-accounts',
+  'schedule-of-investments', 'allocation-terms', 'opening-balances', 'lp-events',
+])
+
+/** True on `/funds/[id]` — the fund detail (lead) page. */
+export function isFundDetailPath(pathname: string): boolean {
+  const m = pathname.match(/^\/funds\/([^/]+)\/?$/)
+  return !!m && !FUND_SUBPAGES.has(m[1])
+}
+
 /**
  * A fetch wrapper that scopes every ledger request to the selected vehicle:
  * appends `?group=` to the URL and injects `group` into JSON POST bodies.

--- a/lib/access/route-domains.ts
+++ b/lib/access/route-domains.ts
@@ -61,6 +61,7 @@ export const ROUTE_DOMAINS: Record<string, RouteAccess> = {
   'api/accounting/chart': { domain: 'accounting' },
   'api/accounting/cutover': { domain: 'accounting' },
   'api/accounting/fund-economics': { domain: 'accounting' },
+  'api/accounting/fund-timeseries': { domain: 'accounting' },
   'api/accounting/investments': { domain: 'accounting' },
   'api/accounting/journal': { domain: 'accounting' },
   'api/accounting/ledger-text': { domain: 'accounting' },

--- a/lib/accounting/fund-economics.ts
+++ b/lib/accounting/fund-economics.ts
@@ -29,6 +29,7 @@ import { computeCapitalAccounts, bucketForSourceType, emptyAccount, type Capital
 import { loadCommitmentEvents, commitmentsFrom } from './terms'
 import { commitmentsFromPositions } from './lp-positions'
 import { loadEntityNames, loadOwnership, listVehicles } from './load'
+import { vehicleIdByName } from './vehicle-id'
 import { loadFundPreload, vehicleCapitalPreload, commitmentEventsForGroup, type FundPreload } from './fund-preload'
 import { xirr, type CashFlow } from '@/lib/xirr'
 import { lpRatios } from '@/lib/lp-metrics'
@@ -51,6 +52,9 @@ export interface FundMetrics {
 
 export interface VehicleEconomics {
   vehicle: string
+  /** The vehicle's stable `fund_vehicles.id`, when it has a registry row — the key the detail
+   *  page routes on. Null for legacy vehicles that exist only as a portfolio_group string. */
+  id: string | null
   /** The vehicle's vintage year, if recorded. Nothing derives this — it is stated. */
   vintageYear: number | null
   source: 'ledger' | 'events'
@@ -130,13 +134,16 @@ export async function vehicleEconomics(
   // With a preload, ownership, entity names/classes, capital source and vintage come from the
   // one fund-wide read; without it (direct callers) each still loads per-vehicle as before.
   const idMap = preload?.idMap
-  const [{ source, postings }, commitmentEvents, owners, names, classes, vintage] = await Promise.all([
+  const [{ source, postings }, commitmentEvents, owners, names, classes, vintage, id] = await Promise.all([
     loadCapitalPostings(admin, fundId, group, asOf, idMap, preload ? vehicleCapitalPreload(preload, group) : undefined),
     loadCommitmentEvents(admin, fundId, group, idMap, preload ? commitmentEventsForGroup(preload, group) : undefined),
     preload ? Promise.resolve(preload.ownershipByGroup.get(group) ?? []) : loadOwnership(admin, fundId, group),
     preload ? Promise.resolve(preload.entityNames) : loadEntityNames(admin, fundId, group),
     preload ? Promise.resolve(preload.entityClasses) : loadEntityClasses(admin, fundId),
     preload ? Promise.resolve(preload.vintageByName.get(group) ?? null) : loadVintage(admin, fundId, group),
+    // The stable registry id the detail page routes on. From the preload's name→id map when we
+    // have it, else a per-vehicle lookup. Null for a legacy portfolio_group with no registry row.
+    vehicleIdByName(admin, fundId, group, idMap),
   ])
 
   const accounts = computeCapitalAccounts(postings)
@@ -205,6 +212,7 @@ export async function vehicleEconomics(
 
   return {
     vehicle: group,
+    id,
     vintageYear: vintage,
     source,
     lpCount: lpIds.size,

--- a/lib/accounting/fund-timeseries.test.ts
+++ b/lib/accounting/fund-timeseries.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import { buildCapitalSeries, quarterEndsThrough, type CapitalSeriesPoint } from './fund-timeseries'
+
+// Postings are DEBIT-POSITIVE deltas to LP equity (credit-normal), so a contribution — which
+// increases capital — arrives as a NEGATIVE amount, and `capitalDelta = -amount` flips it back
+// positive. Getting that sign backwards inverts the whole fund, so it's the first thing pinned.
+const p = (entryDate: string, sourceType: string, capitalDelta: number) => ({
+  entryDate, sourceType, amount: -capitalDelta, // store as debit-positive
+})
+
+const at = (points: CapitalSeriesPoint[], label: string) => points.find(x => x.label === label)!
+
+describe('quarterEndsThrough', () => {
+  it('walks quarter-ends from the start quarter through the end date, inclusive', () => {
+    expect(quarterEndsThrough('2024-02-10', '2024-09-30')).toEqual([
+      '2024-03-31', '2024-06-30', '2024-09-30',
+    ])
+  })
+
+  it('appends the reporting date\'s own quarter even when it is mid-quarter', () => {
+    // Ends 2024-08-15 → the Q3 bucket must exist so the curve ends on "now", not on Q2.
+    expect(quarterEndsThrough('2024-01-05', '2024-08-15')).toEqual([
+      '2024-03-31', '2024-06-30', '2024-09-30',
+    ])
+  })
+})
+
+describe('buildCapitalSeries', () => {
+  const quarters = quarterEndsThrough('2024-01-01', '2024-12-31')
+
+  it('buckets each posting into its quarter and accumulates forward', () => {
+    const series = buildCapitalSeries(
+      [
+        p('2024-01-15', 'capital_call', 1_000_000),   // Q1
+        p('2024-04-20', 'capital_call', 500_000),     // Q2
+        p('2024-07-10', 'distribution', -200_000),    // Q3, returns capital
+      ],
+      quarters,
+    )
+    expect(at(series, "Q1 '24").calledCapital).toBe(1_000_000)
+    expect(at(series, "Q2 '24").calledCapital).toBe(1_500_000) // cumulative
+    expect(at(series, "Q3 '24").calledCapital).toBe(1_500_000) // no new calls
+    expect(at(series, "Q3 '24").distributed).toBe(200_000)     // reported positive
+    expect(at(series, "Q4 '24").calledCapital).toBe(1_500_000) // carries to the end
+  })
+
+  it('composes NAV from the signed buckets, and it ties to their sum', () => {
+    const series = buildCapitalSeries(
+      [
+        p('2024-01-15', 'capital_call', 1_000_000),
+        p('2024-02-01', 'management_fee', -20_000),
+        p('2024-03-01', 'valuation', 300_000),        // unrealized gain
+        p('2024-03-15', 'distribution', -100_000),
+      ],
+      quarters,
+    )
+    const q1 = at(series, "Q1 '24")
+    expect(q1.contributions).toBe(1_000_000)
+    expect(q1.expenses).toBe(-20_000)
+    expect(q1.unrealizedGains).toBe(300_000)
+    expect(q1.distributions).toBe(-100_000)
+    // NAV = sum of every signed component.
+    expect(q1.nav).toBe(1_000_000 - 20_000 + 300_000 - 100_000)
+    const sum = q1.contributions + q1.distributions + q1.operatingIncome +
+      q1.realizedGains + q1.unrealizedGains + q1.expenses + q1.other
+    expect(q1.nav).toBeCloseTo(sum, 2)
+  })
+
+  it('folds reallocations (carry, transfers, unclassified) onto one neutral line', () => {
+    const series = buildCapitalSeries(
+      [
+        p('2024-01-15', 'capital_call', 1_000_000),
+        p('2024-02-01', 'carried_interest', -50_000),
+        p('2024-02-01', 'transfer', 50_000),
+        p('2024-02-01', 'manual', 123),
+      ],
+      quarters,
+    )
+    const q1 = at(series, "Q1 '24")
+    expect(q1.other).toBe(-50_000 + 50_000 + 123)
+    // Whole-fund, carry + transfers net to zero across partners; here `other` still ties into NAV.
+    expect(q1.nav).toBe(1_000_000 + q1.other)
+  })
+
+  it('is empty when there are no quarters', () => {
+    expect(buildCapitalSeries([p('2024-01-01', 'capital_call', 1)], [])).toEqual([])
+  })
+})

--- a/lib/accounting/fund-timeseries.ts
+++ b/lib/accounting/fund-timeseries.ts
@@ -1,0 +1,242 @@
+// Fund growth over time — the time-series behind the /funds/[id] detail page's charts.
+//
+// Everything here is WHOLE-FUND and derived from the same two producers the rest of the
+// section reads:
+//
+//   • LP capital postings (loadCapitalPostings) — dated, debit-positive deltas to partners'
+//     equity accounts, bucketed by source_type. These give the net-of-fund cash flows
+//     (called capital, distributions) and the NAV composition (contributions, gains,
+//     expenses, …). Summed across EVERY partner, the reallocation buckets — carried interest,
+//     transfers, unclassified — net to ~zero, so a whole-fund series leaks none of the GP's
+//     economics and needs no gp_economics gate. `ending` NAV is the raw cumulative sum of the
+//     deltas, so the composition always ties to the ledger.
+//
+//   • The portfolio tracker (computeSummary, the canonical roll-up in lib/investments.ts) —
+//     re-valued AS OF each period end. This gives the GROSS, deal-level view: capital invested
+//     into companies and proceeds returned from them, which is a different thing from the LPs'
+//     called capital and distributions.
+//
+// The grid is quarterly. Each point carries CUMULATIVE (inception-to-period-end) figures so the
+// charts read as growth curves rather than per-quarter flows.
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { roundCents } from './ledger'
+import { loadCapitalPostings } from './capital-source'
+import { bucketForSourceType } from './capital-account'
+import { txnsForVehicle } from './soi'
+import { computeSummary } from '@/lib/investments'
+import type { InvestmentTransaction, CompanyStatus } from '@/lib/types/database'
+
+export interface FundTimeseriesPoint {
+  /** Quarter-end date (YYYY-MM-DD). */
+  period: string
+  /** Short label, e.g. "Q1 '24". */
+  label: string
+
+  // ── Net, from LP capital accounts (cumulative) ────────────────────────────
+  /** Called (paid-in) capital to date. */
+  calledCapital: number
+  /** Capital returned to partners to date (positive). */
+  distributed: number
+
+  // ── NAV composition (cumulative, signed so the segments sum to `nav`) ──────
+  contributions: number
+  /** Negative — capital returned reduces NAV. */
+  distributions: number
+  operatingIncome: number
+  realizedGains: number
+  unrealizedGains: number
+  /** Negative — management fees + partnership expenses. */
+  expenses: number
+  /** Transfers + FX translation + anything unclassified. Nets to ~0 whole-fund. */
+  other: number
+  /** = sum of the composition segments = ending partners' capital. */
+  nav: number
+
+  // ── Gross, from the portfolio tracker (cumulative, as of the period) ───────
+  /** Capital deployed into companies to date. */
+  investedCapital: number
+  /** Proceeds realized from companies to date. */
+  proceeds: number
+  /** Carrying value of the portfolio at the period end. */
+  portfolioValue: number
+}
+
+export interface FundTimeseries {
+  points: FundTimeseriesPoint[]
+  /** True once the vehicle holds any tracked investment — drives the gross toggle. */
+  hasGross: boolean
+}
+
+const r = roundCents
+
+/** Last calendar day of the quarter containing `d`, as YYYY-MM-DD (UTC). */
+function quarterEndOf(d: Date): string {
+  const y = d.getUTCFullYear()
+  const endMonth = Math.floor(d.getUTCMonth() / 3) * 3 + 2 // 2, 5, 8, 11
+  return new Date(Date.UTC(y, endMonth + 1, 0)).toISOString().slice(0, 10)
+}
+
+function quarterLabel(dateStr: string): string {
+  const d = new Date(dateStr + 'T00:00:00Z')
+  const q = Math.floor(d.getUTCMonth() / 3) + 1
+  return `Q${q} '${String(d.getUTCFullYear()).slice(2)}`
+}
+
+/** Every quarter-end from the quarter containing `start` through `end`, inclusive. Capped. */
+export function quarterEndsThrough(start: string, end: string): string[] {
+  const out: string[] = []
+  let cur = quarterEndOf(new Date(start + 'T00:00:00Z'))
+  while (cur <= end && out.length < 80) {
+    out.push(cur)
+    const next = new Date(new Date(cur + 'T00:00:00Z').getTime() + 86_400_000)
+    cur = quarterEndOf(next)
+  }
+  // The reporting date itself may fall mid-quarter — make sure it's represented so the
+  // curve ends on "now" rather than on the last completed quarter.
+  const endQ = quarterEndOf(new Date(end + 'T00:00:00Z'))
+  if (out.length > 0 && out[out.length - 1] !== endQ && endQ > out[out.length - 1] && out.length < 80) {
+    out.push(endQ)
+  }
+  return out
+}
+
+/** The capital-account half of a point — everything derivable from LP postings alone. */
+export type CapitalSeriesPoint = Omit<FundTimeseriesPoint, 'investedCapital' | 'proceeds' | 'portfolioValue'>
+
+/** A capital posting, narrowed to what the series needs. */
+interface SeriesPosting { entryDate?: string | null; sourceType?: string | null; amount: number }
+
+/**
+ * The pure capital-account time-series: bucket dated postings into quarters, then roll them
+ * forward into cumulative points. DB-free and deterministic, so the bucketing and the NAV
+ * tie-out can be pinned by a test. `quarters` are the quarter-end dates to report, in order.
+ */
+export function buildCapitalSeries(postings: SeriesPosting[], quarters: string[]): CapitalSeriesPoint[] {
+  if (quarters.length === 0) return []
+
+  const zero = () => ({
+    contributions: 0, distributions: 0, operatingIncome: 0, realizedGains: 0,
+    unrealizedGains: 0, expenses: 0, other: 0,
+  })
+  const perQuarter = new Map<string, ReturnType<typeof zero>>(quarters.map(q => [q, zero()]))
+
+  // The first quarter-end on or after `date` — the quarter that posting lands in.
+  const quarterFor = (date: string): string => {
+    for (const q of quarters) if (date <= q) return q
+    return quarters[quarters.length - 1] // shouldn't happen (postings are asOf-scoped); clamp anyway
+  }
+
+  for (const p of postings) {
+    // Undated postings (rare) anchor to the first quarter so they still count toward NAV.
+    const bucket = perQuarter.get(quarterFor(p.entryDate ?? quarters[0]))
+    if (!bucket) continue
+    const delta = -p.amount // credit increases capital
+    switch (bucketForSourceType(p.sourceType)) {
+      case 'contributions': bucket.contributions += delta; break
+      case 'distributions': bucket.distributions += delta; break
+      case 'operatingIncome': bucket.operatingIncome += delta; break
+      case 'realizedGains': bucket.realizedGains += delta; break
+      case 'unrealizedGains': bucket.unrealizedGains += delta; break
+      case 'managementFees':
+      case 'expenses': bucket.expenses += delta; break
+      // beginning/transfers/carriedInterest/fxTranslation/unclassified — reallocations and
+      // opening balances that net to ~0 whole-fund. Kept on one line so the stack still ties.
+      default: bucket.other += delta; break
+    }
+  }
+
+  const running = zero()
+  return quarters.map(q => {
+    const d = perQuarter.get(q)!
+    running.contributions += d.contributions
+    running.distributions += d.distributions
+    running.operatingIncome += d.operatingIncome
+    running.realizedGains += d.realizedGains
+    running.unrealizedGains += d.unrealizedGains
+    running.expenses += d.expenses
+    running.other += d.other
+
+    const nav = r(running.contributions + running.distributions + running.operatingIncome +
+      running.realizedGains + running.unrealizedGains + running.expenses + running.other)
+
+    return {
+      period: q,
+      label: quarterLabel(q),
+      calledCapital: r(running.contributions),
+      distributed: r(-running.distributions),
+      contributions: r(running.contributions),
+      distributions: r(running.distributions),
+      operatingIncome: r(running.operatingIncome),
+      realizedGains: r(running.realizedGains),
+      unrealizedGains: r(running.unrealizedGains),
+      expenses: r(running.expenses),
+      other: r(running.other),
+      nav,
+    }
+  })
+}
+
+/**
+ * Whole-fund growth time-series for one vehicle.
+ *
+ * `asOf` (YYYY-MM-DD) caps the series; it defaults to today. A vehicle with no capital and no
+ * tracked investments returns an empty series rather than a flat line of zeroes.
+ */
+export async function fundTimeseries(
+  admin: SupabaseClient,
+  fundId: string,
+  group: string,
+  asOf?: string,
+): Promise<FundTimeseries> {
+  const endDate = asOf && /^\d{4}-\d{2}-\d{2}$/.test(asOf) ? asOf : new Date().toISOString().slice(0, 10)
+
+  const [{ postings }, { data: txnRows }, { data: companyRows }] = await Promise.all([
+    loadCapitalPostings(admin, fundId, group, endDate),
+    admin.from('investment_transactions' as any).select('*').eq('fund_id', fundId),
+    admin.from('companies' as any).select('*').eq('fund_id', fundId),
+  ])
+
+  const txns = ((txnRows as InvestmentTransaction[]) ?? [])
+  const companies = ((companyRows as any[]) ?? [])
+
+  // Companies this vehicle actually holds — same test the schedule of investments uses.
+  const byCompany = new Map<string, InvestmentTransaction[]>()
+  for (const t of txns) {
+    if (!byCompany.has(t.company_id)) byCompany.set(t.company_id, [])
+    byCompany.get(t.company_id)!.push(t)
+  }
+  const held = companies
+    .map(c => ({ status: (c.status ?? 'active') as CompanyStatus, relevant: txnsForVehicle(byCompany.get(c.id) ?? [], group) }))
+    .filter(c => c.relevant.some(t => t.transaction_type === 'investment' && t.portfolio_group === group))
+
+  // Earliest activity across both producers — where the curve should start.
+  const postingDates = postings.map(p => p.entryDate).filter((d): d is string => !!d)
+  const txnDates = held.flatMap(c => c.relevant.map(t => t.transaction_date).filter((d): d is string => !!d))
+  const allDates = [...postingDates, ...txnDates].filter(d => d <= endDate).sort()
+  if (allDates.length === 0) return { points: [], hasGross: held.length > 0 }
+
+  const quarters = quarterEndsThrough(allDates[0], endDate)
+  const capital = buildCapitalSeries(postings, quarters)
+
+  // Layer the gross (deal-level) view on: re-value the tracker AS OF each quarter end.
+  // computeSummary is the canonical valuation — deliberately not re-derived here.
+  const points: FundTimeseriesPoint[] = capital.map(pt => {
+    const asOfDate = new Date(pt.period + 'T00:00:00Z')
+    let investedCapital = 0, proceeds = 0, portfolioValue = 0
+    for (const c of held) {
+      const s = computeSummary(c.relevant, c.status, asOfDate)
+      investedCapital += s.totalInvested
+      proceeds += s.totalRealized
+      portfolioValue += s.unrealizedValue
+    }
+    return {
+      ...pt,
+      investedCapital: r(investedCapital),
+      proceeds: r(proceeds),
+      portfolioValue: r(portfolioValue),
+    }
+  })
+
+  return { points, hasGross: held.length > 0 }
+}

--- a/lib/accounting/vehicle-id.ts
+++ b/lib/accounting/vehicle-id.ts
@@ -44,3 +44,19 @@ export async function vehicleIdByName(
   const { data: alias } = await (admin as any).from('fund_vehicles').select('id').eq('fund_id', fundId).contains('aliases', [name]).maybeSingle()
   return (alias?.id as string) ?? null
 }
+
+/**
+ * Resolve a `fund_vehicles.id` back to its current name, scoped to the fund. The inverse of
+ * `vehicleIdByName`, for the URL-addressable surfaces (e.g. /funds/[id]) that route on the stable
+ * UUID — like companies and LPs — rather than the mutable name. Returns null when the id isn't a
+ * vehicle in this fund, so a stale or cross-fund link resolves to "not found" instead of leaking.
+ */
+export async function vehicleNameById(
+  admin: SupabaseClient,
+  fundId: string,
+  id: string,
+): Promise<string | null> {
+  const { data } = await (admin as any)
+    .from('fund_vehicles').select('name').eq('id', id).eq('fund_id', fundId).maybeSingle()
+  return (data?.name as string) ?? null
+}


### PR DESCRIPTION
Clicking a vehicle on the /funds overview now opens a dedicated detail page
instead of jumping straight to the admin/status view. The detail page carries:

- Key metrics in the same Card boxes as the overview and LP snapshot
  (committed, called, uncalled, distributed, NAV, TVPI, DPI, IRR), with the
  net-to-LP / whole-fund lens when a GP class exists — all reusing the existing
  fund-economics numbers so they reconcile exactly.
- Investment breakdowns from the schedule of investments (by industry, by asset
  type / geography, plus largest holdings).
- Fund growth over time: a stacked bar chart toggling between the net view
  (called capital + distributions) and the gross view (invested capital +
  proceeds).
- NAV growth over time: stacked composition (net paid-in, realized and
  unrealized gains, operating income, expenses) with the NAV total traced as a
  line.

The growth charts are driven by a new whole-fund time-series endpoint
(/api/accounting/fund-timeseries), built from the dated LP capital postings for
the net/NAV series and the canonical portfolio valuation (computeSummary),
re-valued as of each quarter, for the gross series. Whole-fund, so the carry and
transfer reallocations net to zero and no gp_economics carve-out is needed; the
pure bucketing/roll-forward is covered by tests.

/funds/status keeps its role as the admin page and is linked from the detail
header. Like /funds, the detail route owns its own layout (no vehicle-selector
bar — the URL pins the vehicle).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WQsyXL8ZeeAwpkL1SqZazZ