### PR TITLE
feat(emails): configure company and metrics from the email detail page

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -169,7 +169,7 @@ The system ships with a curated registry of compliance items covering SEC filing
 
 Asks lets you send reporting request emails to portfolio companies. Compose a message, select which companies should receive it, and send it out. The system tracks each request so you know what was sent and when.
 
-The email composer supports a customizable subject and body. Each request is logged with its recipient list, send timestamp, and delivery results. When companies reply to your ask email with their report, those replies flow into the Inbound pipeline automatically.
+The email composer supports a customizable subject and body, plus optional CC and BCC lists (comma-separated) that are copied on every email in the send. Each request is logged with its recipient list, the CC/BCC used, send timestamp, and delivery results. When companies reply to your ask email with their report, those replies flow into the Inbound pipeline automatically.
 
 ![Asks](public/screenshots/asks.png)
 

--- a/app/(app)/emails/[id]/metrics-section.tsx
+++ b/app/(app)/emails/[id]/metrics-section.tsx
@@ -1,0 +1,339 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { CompanyForm } from '@/components/company-form'
+import { MetricForm } from '@/components/metric-form'
+import { BarChart3, Building2, Check, Loader2, Plus, Sparkles } from 'lucide-react'
+import type { Company } from '@/lib/types/database'
+
+// The same "assign a company, then tell Claude what to extract" step the email review modal
+// offers, on the detail page — a failed email lands here, not in the modal, and without this
+// section there is no way to configure metrics before hitting Process email.
+
+interface MetricInfo {
+  id: string
+  name: string
+  slug: string
+  unit: string | null
+}
+
+interface Props {
+  emailId: string
+  initialCompany: { id: string; name: string } | null
+}
+
+export function EmailMetricsSection({ emailId, initialCompany }: Props) {
+  const router = useRouter()
+
+  const [company, setCompany] = useState(initialCompany)
+
+  // Company assignment
+  const [companies, setCompanies] = useState<{ id: string; name: string }[]>([])
+  const [selectedCompanyId, setSelectedCompanyId] = useState('')
+  const [assigning, setAssigning] = useState(false)
+  const [showCompanyForm, setShowCompanyForm] = useState(false)
+
+  // Metrics
+  const [metrics, setMetrics] = useState<MetricInfo[]>([])
+  const [loadingMetrics, setLoadingMetrics] = useState(!!initialCompany)
+  const [showMetricForm, setShowMetricForm] = useState(false)
+  const [metricsAdded, setMetricsAdded] = useState(0)
+
+  // Fund default metric profile
+  const [defaultsAvailable, setDefaultsAvailable] = useState(0)
+  const [seeding, setSeeding] = useState(false)
+
+  const loadMetrics = useCallback(async (companyId: string) => {
+    setLoadingMetrics(true)
+    try {
+      const res = await fetch(`/api/companies/${companyId}/metrics`)
+      if (res.ok) {
+        const data = (await res.json()) as MetricInfo[]
+        setMetrics(data.map(m => ({ id: m.id, name: m.name, slug: m.slug, unit: m.unit ?? null })))
+      }
+    } catch {
+      // leave the list as-is; the section still offers Add metric
+    } finally {
+      setLoadingMetrics(false)
+    }
+  }, [])
+
+  const loadDefaults = useCallback(async (companyId: string) => {
+    try {
+      const res = await fetch(`/api/companies/${companyId}/default-metrics`)
+      if (!res.ok) return
+      const data = (await res.json()) as { status: string }[]
+      setDefaultsAvailable(data.filter(d => d.status === 'available').length)
+    } catch {
+      setDefaultsAvailable(0)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (company) {
+      loadMetrics(company.id)
+      loadDefaults(company.id)
+    } else {
+      setMetrics([])
+      setDefaultsAvailable(0)
+      setLoadingMetrics(false)
+      // Only needed for the picker, so fetch it only when there is nothing assigned
+      fetch('/api/companies')
+        .then(res => (res.ok ? res.json() : []))
+        .then((data: { id: string; name: string; status: string }[]) =>
+          setCompanies(
+            data
+              .filter(c => c.status === 'active')
+              .map(c => ({ id: c.id, name: c.name }))
+              .sort((a, b) => a.name.localeCompare(b.name))
+          )
+        )
+        .catch(() => setCompanies([]))
+    }
+  }, [company, loadMetrics, loadDefaults])
+
+  async function assignCompany(companyId: string, name: string) {
+    const res = await fetch(`/api/emails/${emailId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ companyId }),
+    })
+    if (!res.ok) {
+      const d = await res.json().catch(() => ({}))
+      throw new Error(d.error ?? 'Failed to assign company')
+    }
+    setCompany({ id: companyId, name })
+    setSelectedCompanyId('')
+    setShowCompanyForm(false)
+    router.refresh()
+  }
+
+  async function handleAssignExisting() {
+    const picked = companies.find(c => c.id === selectedCompanyId)
+    if (!picked) return
+    setAssigning(true)
+    try {
+      await assignCompany(picked.id, picked.name)
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Error assigning company')
+    } finally {
+      setAssigning(false)
+    }
+  }
+
+  async function handleCompanyCreated(created: Company) {
+    try {
+      await assignCompany(created.id, created.name)
+      setShowMetricForm(true)
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Error assigning company')
+    }
+  }
+
+  function handleMetricAdded() {
+    setMetricsAdded(prev => prev + 1)
+    if (company) {
+      loadMetrics(company.id)
+      loadDefaults(company.id)
+    }
+  }
+
+  async function handleSeedDefaults() {
+    if (!company) return
+    setSeeding(true)
+    try {
+      const res = await fetch(`/api/companies/${company.id}/default-metrics`, { method: 'POST' })
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}))
+        throw new Error(d.error ?? 'Failed to add default metrics')
+      }
+      const { inserted } = (await res.json()) as { inserted: number }
+      toast.success(`${inserted} default metric${inserted === 1 ? '' : 's'} added`)
+      await Promise.all([loadMetrics(company.id), loadDefaults(company.id)])
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Error adding default metrics')
+    } finally {
+      setSeeding(false)
+    }
+  }
+
+  const hasMetrics = metrics.length > 0
+
+  return (
+    <section>
+      <div className="flex items-center gap-2 mb-2">
+        <h2 className="text-base font-semibold">Metrics</h2>
+        {company && !loadingMetrics && (
+          <span className="text-xs text-muted-foreground">
+            {hasMetrics ? `${metrics.length} configured` : 'none configured'}
+          </span>
+        )}
+      </div>
+
+      {/* ── No company: assign one first ── */}
+      {!company && (
+        <div className="rounded-card border bg-muted/30 p-4 space-y-3">
+          <p className="text-sm text-muted-foreground flex items-start gap-2">
+            <Building2 className="h-4 w-4 mt-0.5 shrink-0" />
+            <span>
+              No company assigned, so there are no metrics to configure. Pick the company this
+              email reports on, or create it.
+            </span>
+          </p>
+
+          {!showCompanyForm && (
+            <>
+              <div className="flex flex-col sm:flex-row gap-2">
+                <select
+                  value={selectedCompanyId}
+                  onChange={e => setSelectedCompanyId(e.target.value)}
+                  className="h-9 rounded-md border border-input bg-background px-3 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 flex-1"
+                >
+                  <option value="">Select a company…</option>
+                  {companies.map(c => (
+                    <option key={c.id} value={c.id}>
+                      {c.name}
+                    </option>
+                  ))}
+                </select>
+                <Button
+                  size="sm"
+                  onClick={handleAssignExisting}
+                  disabled={!selectedCompanyId || assigning}
+                  className="gap-1.5 shrink-0"
+                >
+                  {assigning ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Check className="h-3.5 w-3.5" />
+                  )}
+                  Assign
+                </Button>
+              </div>
+
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <div className="h-px flex-1 bg-border" />
+                <span>or</span>
+                <div className="h-px flex-1 bg-border" />
+              </div>
+
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setShowCompanyForm(true)}
+                className="gap-1.5"
+              >
+                <Plus className="h-3.5 w-3.5" />
+                Create New Company
+              </Button>
+            </>
+          )}
+
+          {showCompanyForm && (
+            <div className="rounded-card border bg-background p-4">
+              <CompanyForm
+                onSuccess={handleCompanyCreated}
+                onCancel={() => setShowCompanyForm(false)}
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ── Company assigned: configure what Claude should extract ── */}
+      {company && (
+        <div className="space-y-3">
+          {loadingMetrics && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading metrics…
+            </div>
+          )}
+
+          {!loadingMetrics && hasMetrics && (
+            <div className="flex flex-wrap gap-1.5">
+              {metrics.map(m => (
+                <span
+                  key={m.id}
+                  className="inline-flex items-center gap-1 rounded-md border bg-muted/50 px-2 py-0.5 text-xs"
+                >
+                  {m.name}
+                  {m.unit && <span className="text-muted-foreground">({m.unit})</span>}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {!loadingMetrics && !hasMetrics && (
+            <p className="text-sm text-muted-foreground flex items-start gap-2">
+              <BarChart3 className="h-4 w-4 mt-0.5 shrink-0" />
+              <span>
+                {company.name} has no metrics configured, so the pipeline has nothing to look for.
+                Add at least one, then run Process email below.
+              </span>
+            </p>
+          )}
+
+          {metricsAdded > 0 && (
+            <p className="text-xs text-success flex items-center gap-1">
+              <Check className="h-3 w-3" />
+              {metricsAdded} metric{metricsAdded !== 1 ? 's' : ''} added — run Process email below to
+              extract values.
+            </p>
+          )}
+
+          {showMetricForm ? (
+            <div className="rounded-card border bg-muted/30 p-4">
+              <MetricForm
+                key={metricsAdded}
+                companyId={company.id}
+                onSuccess={handleMetricAdded}
+                onCancel={() => setShowMetricForm(false)}
+              />
+            </div>
+          ) : (
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setShowMetricForm(true)}
+                className="gap-1.5"
+              >
+                <Plus className="h-3.5 w-3.5" />
+                Add Metric
+              </Button>
+
+              {defaultsAvailable > 0 && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleSeedDefaults}
+                  disabled={seeding}
+                  className="gap-1.5"
+                >
+                  {seeding ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Sparkles className="h-3.5 w-3.5" />
+                  )}
+                  Add {defaultsAvailable} fund default{defaultsAvailable !== 1 ? 's' : ''}
+                </Button>
+              )}
+
+              <Link
+                href={`/companies/${company.id}`}
+                className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2"
+              >
+                Manage on {company.name}
+              </Link>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/app/(app)/emails/[id]/page.tsx
+++ b/app/(app)/emails/[id]/page.tsx
@@ -14,6 +14,7 @@ import { UploadDocumentButton } from './upload-document-button'
 import { SaveToDriveButton } from './save-to-drive-button'
 import { CollapsibleJson } from './collapsible-json'
 import { ReviewItems } from './review-items'
+import { EmailMetricsSection } from './metrics-section'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -251,6 +252,9 @@ export default async function EmailDetailPage({ params }: { params: { id: string
 
       {/* Review items */}
       <ReviewItems emailId={params.id} hasReviews={reviews.length > 0} />
+
+      {/* Company + metric configuration — the same options the review modal offers */}
+      <EmailMetricsSection emailId={params.id} initialCompany={company} />
 
       {/* Attachments */}
       {attachments.length > 0 && (

--- a/app/(app)/requests/page.tsx
+++ b/app/(app)/requests/page.tsx
@@ -133,6 +133,11 @@ export default function RequestsPage() {
       if (lastSent) {
         setBodyText(lastSent.body_html as string)
         if (lastSent.subject) setSubject(lastSent.subject as string)
+        // Restored the same way as subject and body: the same people are usually copied
+        // every quarter. Empty string when the last send had none, so the field stays blank
+        // rather than holding a stale list.
+        setCc((lastSent.cc as string | null) ?? '')
+        setBcc((lastSent.bcc as string | null) ?? '')
       }
     }
 
@@ -411,7 +416,8 @@ export default function RequestsPage() {
               placeholder="cc@example.com, someone@example.com"
             />
             <p className="text-xs text-muted-foreground mt-1">
-              Optional. CC'd on every email sent, and visible to recipients.
+              Optional. Separate multiple addresses with commas. CC'd on every email sent, and
+              visible to recipients.
             </p>
           </div>
           <div>
@@ -422,7 +428,8 @@ export default function RequestsPage() {
               placeholder="bcc@example.com, someone@example.com"
             />
             <p className="text-xs text-muted-foreground mt-1">
-              Optional. Blind-copied on every email sent — recipients don't see it.
+              Optional. Separate multiple addresses with commas. Blind-copied on every email
+              sent — recipients don't see them.
             </p>
           </div>
         </div>

--- a/app/(app)/requests/page.tsx
+++ b/app/(app)/requests/page.tsx
@@ -87,6 +87,7 @@ export default function RequestsPage() {
   const [subject, setSubject] = useState(DEFAULT_SUBJECT)
   const [bodyText, setBodyText] = useState(DEFAULT_BODY)
   const [cc, setCc] = useState('')
+  const [bcc, setBcc] = useState('')
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [confirmSend, setConfirmSend] = useState(false)
 
@@ -197,6 +198,7 @@ export default function RequestsPage() {
         body_html: plainTextToHtml(bodyText),
         body_text: bodyText,
         cc: cc.trim() || undefined,
+        bcc: bcc.trim() || undefined,
         from_name: fromName.trim() || undefined,
         from_address: fromAddress.trim() || undefined,
         recipients: [{ emails: [testEmail.trim()], companyName: 'Test' }],
@@ -237,6 +239,7 @@ export default function RequestsPage() {
         body_html: plainTextToHtml(bodyText),
         body_text: bodyText,
         cc: cc.trim() || undefined,
+        bcc: bcc.trim() || undefined,
         from_name: fromName.trim() || undefined,
         from_address: fromAddress.trim() || undefined,
         recipients,
@@ -399,16 +402,29 @@ export default function RequestsPage() {
           </p>
         </div>
 
-        <div>
-          <Label>CC</Label>
-          <Input
-            value={cc}
-            onChange={(e) => setCc(e.target.value)}
-            placeholder="cc@example.com"
-          />
-          <p className="text-xs text-muted-foreground mt-1">
-            Optional. CC'd on every email sent.
-          </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div>
+            <Label>CC</Label>
+            <Input
+              value={cc}
+              onChange={(e) => setCc(e.target.value)}
+              placeholder="cc@example.com, someone@example.com"
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              Optional. CC'd on every email sent, and visible to recipients.
+            </p>
+          </div>
+          <div>
+            <Label>BCC</Label>
+            <Input
+              value={bcc}
+              onChange={(e) => setBcc(e.target.value)}
+              placeholder="bcc@example.com, someone@example.com"
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              Optional. Blind-copied on every email sent — recipients don't see it.
+            </p>
+          </div>
         </div>
       </div>
 

--- a/app/api/requests/route.ts
+++ b/app/api/requests/route.ts
@@ -21,7 +21,7 @@ export async function GET() {
 
   const { data, error } = await admin
     .from('email_requests')
-    .select('id, subject, body_html, recipients, quarter_label, status, sent_at, send_results, created_at')
+    .select('id, subject, body_html, cc, bcc, recipients, quarter_label, status, sent_at, send_results, created_at')
     .eq('fund_id', membership.fund_id)
     .order('created_at', { ascending: false })
     .limit(20)

--- a/app/api/requests/send/route.ts
+++ b/app/api/requests/send/route.ts
@@ -92,7 +92,9 @@ export async function POST(req: NextRequest) {
     sent_by: user.id,
     status: 'sent',
     sent_at: new Date().toISOString(),
-    send_results: { sent, failed, cc: ccList.value ?? null, bcc: bccList.value ?? null, details: results },
+    cc: ccList.value ?? null,
+    bcc: bccList.value ?? null,
+    send_results: { sent, failed, details: results },
   })
 
   logActivity(admin, membership.fund_id, user.id, 'requests.send', { recipientCount: recipients.length })

--- a/app/api/requests/send/route.ts
+++ b/app/api/requests/send/route.ts
@@ -3,7 +3,7 @@ import { createClient } from '@/lib/supabase/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { assertWriteAccess } from '@/lib/api-helpers'
 import { sanitizeHtml } from '@/lib/sanitize-html'
-import { getOutboundConfig, sendOutboundEmail } from '@/lib/email'
+import { getOutboundConfig, parseAddressList, sendOutboundEmail } from '@/lib/email'
 import { rateLimit } from '@/lib/rate-limit'
 import { logActivity } from '@/lib/activity'
 
@@ -31,11 +31,17 @@ export async function POST(req: NextRequest) {
   if (membership.role !== 'admin') return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
 
   const body = await req.json()
-  const { subject, body_html, body_text, recipients, quarter_label, cc, from_name, from_address } = body
+  const { subject, body_html, body_text, recipients, quarter_label, cc, bcc, from_name, from_address } = body
 
   if (!subject?.trim()) return NextResponse.json({ error: 'Subject is required' }, { status: 400 })
   if (!body_html?.trim() && !body_text?.trim()) return NextResponse.json({ error: 'Body is required' }, { status: 400 })
   if (!recipients?.length) return NextResponse.json({ error: 'No recipients selected' }, { status: 400 })
+
+  // Cc/Bcc are free text, so normalize before they reach a provider (or a MIME header)
+  const ccList = parseAddressList(cc)
+  if (ccList.invalid) return NextResponse.json({ error: `Invalid CC address: ${ccList.invalid}` }, { status: 400 })
+  const bccList = parseAddressList(bcc)
+  if (bccList.invalid) return NextResponse.json({ error: `Invalid BCC address: ${bccList.invalid}` }, { status: 400 })
 
   // Get the fund's outbound email config
   const config = await getOutboundConfig(admin, membership.fund_id, 'asks')
@@ -62,7 +68,8 @@ export async function POST(req: NextRequest) {
         from,
         subject: subject.trim(),
         html: sanitizeHtml(body_html.trim()),
-        cc: cc?.trim() || undefined,
+        cc: ccList.value,
+        bcc: bccList.value,
       })
       results.push({ emails: toAddresses, success: true, messageId: result.id?.toString() })
     } catch (err) {
@@ -85,7 +92,7 @@ export async function POST(req: NextRequest) {
     sent_by: user.id,
     status: 'sent',
     sent_at: new Date().toISOString(),
-    send_results: { sent, failed, details: results },
+    send_results: { sent, failed, cc: ccList.value ?? null, bcc: bccList.value ?? null, details: results },
   })
 
   logActivity(admin, membership.fund_id, user.id, 'requests.send', { recipientCount: recipients.length })

--- a/lib/email.test.ts
+++ b/lib/email.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { parseAddressList } from './email'
+
+describe('parseAddressList', () => {
+  it('returns undefined for empty input', () => {
+    expect(parseAddressList(undefined)).toEqual({ value: undefined })
+    expect(parseAddressList('')).toEqual({ value: undefined })
+    expect(parseAddressList('   ')).toEqual({ value: undefined })
+  })
+
+  it('normalizes comma- and semicolon-separated lists', () => {
+    expect(parseAddressList('a@b.com,  c@d.com ; e@f.com')).toEqual({
+      value: 'a@b.com, c@d.com, e@f.com',
+    })
+  })
+
+  it('accepts display-name form', () => {
+    expect(parseAddressList('Ada Lovelace <ada@example.com>')).toEqual({
+      value: 'Ada Lovelace <ada@example.com>',
+    })
+  })
+
+  it('reports the first entry that is not an address', () => {
+    expect(parseAddressList('a@b.com, not-an-email')).toEqual({ invalid: 'not-an-email' })
+    expect(parseAddressList('Ada <ada@>')).toEqual({ invalid: 'Ada <ada@>' })
+  })
+
+  // A Cc/Bcc value reaches a raw MIME header on the Gmail path, so a newline in it
+  // would otherwise inject headers of the sender's choosing.
+  it('strips CR/LF rather than letting it through', () => {
+    expect(parseAddressList('a@b.com\r\nBcc: attacker@evil.com')).toEqual({
+      invalid: 'a@b.com Bcc: attacker@evil.com',
+    })
+    expect(parseAddressList('a@b.com,\n c@d.com')).toEqual({ value: 'a@b.com, c@d.com' })
+  })
+})

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
+import { EMAIL_RE } from '@/lib/deals/submission-validation'
 
 export interface EmailAttachment {
   filename: string
@@ -12,6 +13,7 @@ export interface EmailParams {
   subject: string
   html: string
   cc?: string
+  bcc?: string
   attachments?: EmailAttachment[]
 }
 
@@ -32,6 +34,7 @@ async function sendViaResend(apiKey: string, params: EmailParams) {
     from: params.from || process.env.EMAIL_FROM || 'onboarding@resend.dev',
     to: params.to,
     cc: params.cc || undefined,
+    bcc: params.bcc || undefined,
     subject: params.subject,
     html: params.html,
     attachments: params.attachments?.map(a => ({ filename: a.filename, content: a.content })),
@@ -46,6 +49,7 @@ async function sendViaPostmark(serverToken: string, params: EmailParams) {
     From: params.from || process.env.EMAIL_FROM || 'noreply@example.com',
     To: params.to,
     Cc: params.cc || undefined,
+    Bcc: params.bcc || undefined,
     Subject: params.subject,
     HtmlBody: params.html,
     Attachments: params.attachments?.map(a => ({
@@ -67,6 +71,7 @@ async function sendViaMailgun(apiKey: string, domain: string, params: EmailParam
     from: params.from || process.env.EMAIL_FROM || `noreply@${domain}`,
     to: [params.to],
     cc: params.cc || undefined,
+    bcc: params.bcc || undefined,
     subject: params.subject,
     html: params.html,
     attachment: params.attachments?.map(a => ({ filename: a.filename, data: a.content })),
@@ -101,8 +106,33 @@ async function sendViaGmail(admin: SupabaseClient, fundId: string, params: Email
   }
   const accessToken = await getAccessToken(refreshToken, creds.clientId, creds.clientSecret)
 
-  const result = await sendEmail(accessToken, params.to, params.subject, params.html, params.cc, params.attachments)
+  const result = await sendEmail(accessToken, params.to, params.subject, params.html, params.cc, params.bcc, params.attachments)
   return { id: result.id }
+}
+
+/**
+ * Normalize a user-typed Cc/Bcc field into a header-safe address list.
+ *
+ * Accepts comma- or semicolon-separated entries, either bare (`a@b.com`) or with a
+ * display name (`Ada <a@b.com>`). Returns the joined list, or the first entry that
+ * isn't an address so the caller can reject it with a useful message — providers
+ * fail an unparseable Cc with an opaque error, and Gmail would happily put it in a
+ * header.
+ */
+export function parseAddressList(
+  input: string | null | undefined,
+): { value?: string; invalid?: string } {
+  const entries = (input ?? '')
+    .split(/[,;]/)
+    .map(e => e.replace(/[\r\n]+/g, ' ').trim())
+    .filter(Boolean)
+
+  for (const entry of entries) {
+    const address = entry.match(/<([^>]*)>$/)?.[1].trim() ?? entry
+    if (!EMAIL_RE.test(address)) return { invalid: entry }
+  }
+
+  return { value: entries.length ? entries.join(', ') : undefined }
 }
 
 /**

--- a/lib/google/gmail.ts
+++ b/lib/google/gmail.ts
@@ -21,12 +21,20 @@ function encodeMimeParam(value: string): string {
   return `=?UTF-8?B?${Buffer.from(clean, 'utf8').toString('base64')}?=`
 }
 
+// An address-list header value (To/Cc/Bcc). Addresses must stay literal — RFC 2047
+// encoding the whole list would mangle them — so this only strips the CR/LF that
+// would otherwise let a crafted address inject extra MIME headers.
+function encodeAddressList(value: string): string {
+  return value.replace(/[\r\n]+/g, ' ').trim()
+}
+
 export async function sendEmail(
   accessToken: string,
   to: string,
   subject: string,
   htmlBody: string,
   cc?: string,
+  bcc?: string,
   attachments?: GmailAttachment[],
 ): Promise<{ id: string; threadId: string }> {
   // Send as plain text (Content-Type: text/plain) so Gmail applies its own
@@ -44,8 +52,9 @@ export async function sendEmail(
   if (attachments && attachments.length > 0) {
     const { randomUUID } = await import('crypto')
     const boundary = `mixed_${randomUUID().replace(/-/g, '')}`
-    const head = [`To: ${to}`]
-    if (cc?.trim()) head.push(`Cc: ${cc.trim()}`)
+    const head = [`To: ${encodeAddressList(to)}`]
+    if (cc?.trim()) head.push(`Cc: ${encodeAddressList(cc)}`)
+    if (bcc?.trim()) head.push(`Bcc: ${encodeAddressList(bcc)}`)
     head.push(
       `Subject: ${encodeMimeHeader(subject)}`,
       `MIME-Version: 1.0`,
@@ -84,8 +93,9 @@ export async function sendEmail(
 
   // Omit From: — Gmail fills it with the authenticated user. Avoids needing
   // a profile-read scope (gmail.send alone can't call users.getProfile).
-  const headers = [`To: ${to}`]
-  if (cc?.trim()) headers.push(`Cc: ${cc.trim()}`)
+  const headers = [`To: ${encodeAddressList(to)}`]
+  if (cc?.trim()) headers.push(`Cc: ${encodeAddressList(cc)}`)
+  if (bcc?.trim()) headers.push(`Bcc: ${encodeAddressList(bcc)}`)
   headers.push(
     `Subject: ${encodeMimeHeader(subject)}`,
     `MIME-Version: 1.0`,

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -557,7 +557,9 @@ export type Database = {
       }
       email_requests: {
         Row: {
+          bcc: string | null
           body_html: string
+          cc: string | null
           created_at: string
           fund_id: string
           id: string
@@ -571,7 +573,9 @@ export type Database = {
           updated_at: string
         }
         Insert: {
+          bcc?: string | null
           body_html: string
+          cc?: string | null
           created_at?: string
           fund_id: string
           id?: string
@@ -585,7 +589,9 @@ export type Database = {
           updated_at?: string
         }
         Update: {
+          bcc?: string | null
           body_html?: string
+          cc?: string | null
           created_at?: string
           fund_id?: string
           id?: string

--- a/supabase/migrations/20260818000000_email_requests_cc_bcc.sql
+++ b/supabase/migrations/20260818000000_email_requests_cc_bcc.sql
@@ -1,0 +1,19 @@
+-- Cc/Bcc for reporting-request emails.
+--
+-- The composer pre-fills from the last sent request so a quarterly ask does not have to be
+-- retyped. Subject and body already came back that way; the copy lists did not, because they
+-- were never stored — Cc went straight to the provider and was forgotten. These columns hold
+-- the normalized list actually sent (comma-separated, as handed to the provider), which makes
+-- them both the audit record of who was copied and the value the composer restores.
+--
+-- Both nullable: a request with no Cc/Bcc is the common case.
+alter table public.email_requests
+  add column if not exists cc  text,
+  add column if not exists bcc text;
+
+comment on column public.email_requests.cc  is 'Normalized Cc list copied on every email in this send (comma-separated).';
+comment on column public.email_requests.bcc is 'Normalized Bcc list blind-copied on every email in this send (comma-separated).';
+
+-- No grants block: this is an ALTER on an existing table, and table-level grants already
+-- issued to anon/authenticated/service_role cover columns added later. RLS and the existing
+-- "Fund members can manage email_requests" policy are unchanged.

--- a/tests/asks-cc-bcc-roundtrip.test.ts
+++ b/tests/asks-cc-bcc-roundtrip.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import path from 'node:path'
+
+/**
+ * "Pre-filled from your last sent request" spans four files: a column to store the list, an
+ * insert that writes it, a select that returns it, and a composer that reads it back. Break any
+ * one and the field silently comes back blank — the send still succeeds, so nothing else fails.
+ * These assertions pin the chain end to end.
+ */
+
+const root = process.cwd()
+const read = (...p: string[]) => readFileSync(path.join(root, ...p), 'utf8')
+
+describe('Asks Cc/Bcc round-trip', () => {
+  it('stores both lists on email_requests', () => {
+    const dir = path.join(root, 'supabase', 'migrations')
+    const sql = readdirSync(dir)
+      .filter(f => f.endsWith('.sql'))
+      .map(f => readFileSync(path.join(dir, f), 'utf8'))
+      .join('\n')
+      .toLowerCase()
+
+    expect(sql).toMatch(/alter table\s+public\.email_requests[\s\S]{0,200}\bcc\b/)
+    expect(sql).toMatch(/alter table\s+public\.email_requests[\s\S]{0,200}\bbcc\b/)
+  })
+
+  it('writes them on send', () => {
+    const route = read('app', 'api', 'requests', 'send', 'route.ts')
+    expect(route).toMatch(/cc:\s*ccList\.value/)
+    expect(route).toMatch(/bcc:\s*bccList\.value/)
+    // Normalized, not raw: the values reach a MIME header on the Gmail path.
+    expect(route).toContain('parseAddressList')
+  })
+
+  it('returns them from the requests list', () => {
+    const route = read('app', 'api', 'requests', 'route.ts')
+    const select = route.match(/\.select\('([^']*email_requests?[^']*|[^']*subject[^']*)'\)/)?.[1] ?? ''
+    expect(select).toContain('cc')
+    expect(select).toContain('bcc')
+  })
+
+  it('restores them into the composer', () => {
+    const page = read('app', '(app)', 'requests', 'page.tsx')
+    expect(page).toMatch(/setCc\(\(lastSent\.cc/)
+    expect(page).toMatch(/setBcc\(\(lastSent\.bcc/)
+    // And sends what it restored.
+    expect(page).toMatch(/bcc:\s*bcc\.trim\(\)/)
+  })
+})


### PR DESCRIPTION
A failed email opens the detail page, not the review modal, and the page
only displayed the assigned company — there was no way to pick a company or
add metrics before hitting Process email, so the reprocess had nothing to
extract.

Adds the same step the review modal offers: assign an existing company or
create one, list the metrics already configured, add one inline via
MetricForm, and seed the fund's default metric profile when defaults are
still available for the company.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BMzQbPhahCob9XGhBxX62p