### PR TITLE
Make "Exit demo" POST to the logout route instead of linking to it

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -93,7 +93,14 @@ export default async function AppLayout({ children }: { children: React.ReactNod
           <DemoSessionGuard />
           <div className="bg-info text-white text-center text-xs py-1.5 px-4 shrink-0 flex items-center justify-center gap-3">
             <span>Viewing demo &mdash; read only</span>
-            <a href="/api/auth/logout" className="underline underline-offset-2 hover:text-white/80">Exit demo</a>
+            {/* POST, not a link: /api/auth/logout exports only POST, so a GET falls through to
+                Next's 405 handler — a body-less response with no Content-Type, which Chrome
+                cannot render and turns into a download named "logout". The session also
+                survived, because a download never unloads the page and DemoSessionGuard's
+                beforeunload beacon never fired. */}
+            <form action="/api/auth/logout" method="POST">
+              <button type="submit" className="underline underline-offset-2 hover:text-white/80">Exit demo</button>
+            </form>
           </div>
         </>
       )}


### PR DESCRIPTION
The demo banner's Exit demo control was an <a href="/api/auth/logout">, so
clicking it issued a GET. The route exports only POST, so Next fell through
to handleMethodNotAllowedResponse() — `new Response(null, { status: 405 })`,
with no Content-Type. Chrome has nothing to sniff on a body-less response,
ends up with an empty MIME type it cannot render, and converts the
navigation into a download named "logout".

Worse than the stray file: the demo session was never ending. A download
does not unload the page, so DemoSessionGuard's beforeunload beacon never
fired either, and the viewer session survived to shadow the next real login
— exactly what that guard exists to prevent.

Now a POST form, matching the other three logout call sites (app-header,
portal-chrome, app/pending).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YJevbBNw8hViVUHAvfQaez